### PR TITLE
[CEN-1020] Send to sonar all jacoco reports

### DIFF
--- a/.devops/code-review-pipelines.yml
+++ b/.devops/code-review-pipelines.yml
@@ -17,7 +17,7 @@ steps:
       extraProperties: |
         sonar.projectKey=$(SONARCLOUD_PROJECT_KEY)
         sonar.projectName=$(SONARCLOUD_PROJECT_NAME)
-        sonar.junit.reportPaths=**/target/surefire-reports/
+        sonar.junit.reportPaths=**/target/surefire-reports/TEST-*.xml
         sonar.exclusions='**/enums/**, **/model/**, **/*Constant*, **/*Config.java, **/*Scheduler.java, **/*Application.java, **/src/test/**, **/Dummy*.java'
 
   - task: Maven@3

--- a/.devops/code-review-pipelines.yml
+++ b/.devops/code-review-pipelines.yml
@@ -12,10 +12,11 @@ steps:
       SonarCloud: '$(SONARCLOUD_SERVICE_CONN)'
       organization: '$(SONARCLOUD_ORG)'
       scannerMode: Other
+      #        sonar.coverage.jacoco.xmlReportPaths=**/target/site/jacoco-aggregate/jacoco.xml
+
       extraProperties: |
         sonar.projectKey=$(SONARCLOUD_PROJECT_KEY)
         sonar.projectName=$(SONARCLOUD_PROJECT_NAME)
-        sonar.coverage.jacoco.xmlReportPaths=**/target/site/jacoco-aggregate/jacoco.xml
         sonar.junit.reportPaths=**/target/surefire-reports/
         sonar.exclusions='**/enums/**, **/model/**, **/*Constant*, **/*Config.java, **/*Scheduler.java, **/*Application.java, **/src/test/**, **/Dummy*.java'
 

--- a/.devops/code-review-pipelines.yml
+++ b/.devops/code-review-pipelines.yml
@@ -17,7 +17,8 @@ steps:
       extraProperties: |
         sonar.projectKey=$(SONARCLOUD_PROJECT_KEY)
         sonar.projectName=$(SONARCLOUD_PROJECT_NAME)
-        sonar.junit.reportPaths=**/target/surefire-reports/TEST-*.xml
+        sonar.junit.reportPaths=target/surefire-reports
+        sonar.coverage.jacoco.xmlReportPaths=target/site/jacoco-aggregate/jacoco.xml,target/site/jacoco/jacoco.xml
         sonar.exclusions='**/enums/**, **/model/**, **/*Constant*, **/*Config.java, **/*Scheduler.java, **/*Application.java, **/src/test/**, **/Dummy*.java'
 
   - task: Maven@3


### PR DESCRIPTION
#### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to fix the `SonarPrepare` task in code-review pipeline to send all reports (surefire, jacoco and jacoco aggregate) to Sonar Cloud

#### List of Changes

<!--- Describe your changes in detail -->

- Fix regex in `SonarPrepare` task

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR is motivated by the fact that Coverage of 0.0% we are seeing on SonarCloud seems quite unreasonable, so we have to guarantee that all available reports are sent to sonar

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested by running the code review pipeline in a dedicated branch, but only a run on master can tell us if the changes can fix the problem

<!--- What types of tests have you developed? Put an `x` in all the boxes that apply: -->
- [ ] Unit Tests
- [ ] Narrow Integration Tests
- [ ] Integration Tests
- [ ] System Tests
- [ ] Performance Tests
- [ ] User Acceptance Tests
- [ ] Smoke Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Documentation:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
