### PR TITLE
[CEN-1198] Remove hard-coded 0000 MCC

### DIFF
--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/mapper/InboundTransactionFieldSetMapper.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/mapper/InboundTransactionFieldSetMapper.java
@@ -21,6 +21,7 @@ import java.time.format.DateTimeFormatter;
 public class InboundTransactionFieldSetMapper implements FieldSetMapper<InboundTransaction> {
 
     private final String timestampParser;
+    private static final String TIMESTAMP_FIELD = "timestamp";
 
     /**
      * @param fieldSet instance of FieldSet containing fields related to an {@link InboundTransaction}
@@ -28,7 +29,7 @@ public class InboundTransactionFieldSetMapper implements FieldSetMapper<InboundT
      * @throws BindException
      */
     @Override
-    public InboundTransaction mapFieldSet(@Nullable FieldSet fieldSet) {
+    public InboundTransaction mapFieldSet(@Nullable FieldSet fieldSet) throws BindException {
 
         if (fieldSet == null) {
             return null;
@@ -57,18 +58,18 @@ public class InboundTransactionFieldSetMapper implements FieldSetMapper<InboundT
                         .merchantId(fieldSet.readString("merchantID"))
                         .terminalId(fieldSet.readString("terminal_id"))
                         .bin(fieldSet.readString("bank_identification_number"))
-                        .mcc("0000")
+                        .mcc(fieldSet.readString("MCC"))
                         .vat(fieldSet.readString("vat"))
                         .posType(fieldSet.readString("pos_type"))
                         .par(fieldSet.readString("par"))
                         .build();
 
         OffsetDateTime dateTime = dtf != null ?
-                ZonedDateTime.parse(fieldSet.readString("timestamp"), dtf).toOffsetDateTime() :
-                OffsetDateTime.parse(fieldSet.readString("timestamp"));
+                ZonedDateTime.parse(fieldSet.readString(TIMESTAMP_FIELD), dtf).toOffsetDateTime() :
+                OffsetDateTime.parse(fieldSet.readString(TIMESTAMP_FIELD));
 
         if (dateTime != null) {
-            inboundTransaction.setTrxDate(fieldSet.readString("timestamp"));
+            inboundTransaction.setTrxDate(fieldSet.readString(TIMESTAMP_FIELD));
         }
 
         return inboundTransaction;

--- a/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/processor/InboundTransactionItemProcessorValidatorTest.java
+++ b/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/processor/InboundTransactionItemProcessorValidatorTest.java
@@ -4,11 +4,13 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import it.gov.pagopa.rtd.transaction_filter.batch.model.InboundTransaction;
 import it.gov.pagopa.rtd.transaction_filter.service.HpanStoreService;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.BDDMockito;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -19,10 +21,12 @@ import javax.validation.ConstraintViolationException;
 
 public class InboundTransactionItemProcessorValidatorTest {
 
-    private final String STRING_LEN_20 = "12345678901234567890";
-    private final String STRING_LEN_21 = STRING_LEN_20 + "1";
-    private final String STRING_LEN_255 = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345";
-    private final String STRING_LEN_256 = STRING_LEN_255 + "6";
+    private static final String FAKE_ENROLLED_PAN = "pan123";
+    private static final String FAKE_SALT = "testSalt";
+    private static final String STRING_LEN_20 = "12345678901234567890";
+    private static final String STRING_LEN_21 = STRING_LEN_20 + "1";
+    private static final String STRING_LEN_255 = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345";
+    private static final String STRING_LEN_256 = STRING_LEN_255 + "6";
 
     public InboundTransactionItemProcessorValidatorTest() {
         MockitoAnnotations.initMocks(this);
@@ -48,17 +52,21 @@ public class InboundTransactionItemProcessorValidatorTest {
     public void processTransactionWithInvalidAcquirerCodeThrowsException(String acquirerCode) {
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setAcquirerCode(acquirerCode);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
         Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"fae71", "27cd4dd11ea5859", STRING_LEN_20})
     public void processTransactionWithValidAcquirerCode(String acquirerCode) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setAcquirerCode(acquirerCode);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(acquirerCode, outbound.getAcquirerCode());
     }
 
     @ParameterizedTest
@@ -66,17 +74,21 @@ public class InboundTransactionItemProcessorValidatorTest {
     public void processTransactionWithInvalidOperationTypeThrowsException(String operationType) {
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setOperationType(operationType);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
         Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"00", "01", "02", "03", "04"})
     public void processTransactionWithValidOperationType(String operationType) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setOperationType(operationType);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(operationType, outbound.getOperationType());
     }
 
     @ParameterizedTest
@@ -84,17 +96,21 @@ public class InboundTransactionItemProcessorValidatorTest {
     public void processTransactionWithInvalidCircuitTypeThrowsException(String circuitType) {
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setCircuitType(circuitType);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
         Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"00", "01", "02", "03", "04", "05", "06", "07", "08", "09", "10"})
     public void processTransactionWithValidCircuitType(String circuitType) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setCircuitType(circuitType);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(circuitType, outbound.getCircuitType());
     }
 
     @ParameterizedTest
@@ -102,46 +118,79 @@ public class InboundTransactionItemProcessorValidatorTest {
     public void processTransactionWithInvalidPanThrowsException(String pan) {
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setPan(pan);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
         Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"fae71031e132166", "27cd4dd11ea58592f41aaecaa1d31bcd1538ea29c068141daf77744893a2a058", STRING_LEN_255})
     public void processTransactionWithValidPan(String pan) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(pan));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setPan(pan);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        String hashedPan = DigestUtils.sha256Hex(pan + FAKE_SALT);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(hashedPan, outbound.getPan());
     }
 
-    // TODO: datetime
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "  "})
+    public void processTransactionWithInvalidTrxDateThrowsException(String trxDate) {
+        InboundTransaction transaction = fakeInboundTransaction();
+        transaction.setTrxDate(trxDate);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"2020-08-06T12:19:16.000+00:00", "2020-08-07T16:03:53.000+00:00"})
+    public void processTransactionWithValidTrxDate(String trxDate) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
+        InboundTransaction transaction = fakeInboundTransaction();
+        transaction.setTrxDate(trxDate);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(trxDate, outbound.getTrxDate());
+    }
 
     @ParameterizedTest
     @ValueSource(strings = {"", " ", "  "})
     public void processTransactionWithInvalidIdTrxAcquirerThrowsException(String idTrxAcquirer) {
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setIdTrxAcquirer(idTrxAcquirer);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
         Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"fae71031e132166", "27cd4dd11ea58592f41aaecaa1d31bcd1538ea29c068141daf77744893a2a058", STRING_LEN_255})
     public void processTransactionWithValidIdTrxAcquirer(String idTrxAcquirer) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setIdTrxAcquirer(idTrxAcquirer);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(idTrxAcquirer, outbound.getIdTrxAcquirer());
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"", "fae71031e132166", "27cd4dd11ea58592f41aaecaa1d31bcd1538ea29c068141daf77744893a2a058"})
     public void processTransactionWithValidIdTrxIssuer(String idTrxIssuer) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setIdTrxIssuer(idTrxIssuer);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(idTrxIssuer, outbound.getIdTrxIssuer());
     }
 
     @ParameterizedTest
@@ -149,17 +198,21 @@ public class InboundTransactionItemProcessorValidatorTest {
     public void processTransactionWithValidCorrelationId(String correlationId) {
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setCorrelationId(correlationId);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
         processor.process(transaction);
     }
 
     @ParameterizedTest
     @ValueSource(longs = {1000, 200000})
     public void processTransactionWithValidAmount(Long amount) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setAmount(amount);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(amount, outbound.getAmount());
     }
 
     @ParameterizedTest
@@ -167,17 +220,21 @@ public class InboundTransactionItemProcessorValidatorTest {
     public void processTransactionWithInvalidAmountCurrencyThrowsException(String amountCurrency) {
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setAmountCurrency(amountCurrency);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
         Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"978", "12", ""})
     public void processTransactionWithValidAmountCurrency(String amountCurrency) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setAmountCurrency(amountCurrency);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(amountCurrency, outbound.getAmountCurrency());
     }
 
     @ParameterizedTest
@@ -185,17 +242,21 @@ public class InboundTransactionItemProcessorValidatorTest {
     public void processTransactionWithInvalidAcquirerIdThrowsException(String acquirerId) {
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setAcquirerId(acquirerId);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
         Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"fae71031e132166", "27cd4dd11ea58592f41aaecaa1d31bcd1538ea29c068141daf77744893a2a058"})
     public void processTransactionWithValidAcquirerId(String acquirerId) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setAcquirerId(acquirerId);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(acquirerId, outbound.getAcquirerId());
     }
 
     @ParameterizedTest
@@ -203,17 +264,21 @@ public class InboundTransactionItemProcessorValidatorTest {
     public void processTransactionWithInvalidMerchantIdThrowsException(String merchantId) {
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setMerchantId(merchantId);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
         Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"fae71031e132166", "27cd4dd11ea58592f41aaecaa1d31bcd1538ea29c068141daf77744893a2a058"})
     public void processTransactionWithValidMerchantId(String merchantId) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setMerchantId(merchantId);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(merchantId, outbound.getMerchantId());
     }
 
     @ParameterizedTest
@@ -221,17 +286,21 @@ public class InboundTransactionItemProcessorValidatorTest {
     public void processTransactionWithInvalidTerminalIdThrowsException(String terminalId) {
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setTerminalId(terminalId);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
         Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"fae71031e132166", "27cd4dd11ea58592f41aaecaa1d31bcd1538ea29c068141daf77744893a2a058"})
     public void processTransactionWithValidTerminalId(String terminalId) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setTerminalId(terminalId);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(terminalId, outbound.getTerminalId());
     }
 
     @ParameterizedTest
@@ -239,17 +308,21 @@ public class InboundTransactionItemProcessorValidatorTest {
     public void processTransactionWithInvalidBinThrowsException(String bin) {
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setBin(bin);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
         Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"123456", "12345678"})
     public void processTransactionWithValidBin(String bin) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setBin(bin);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(bin, outbound.getBin());
     }
 
     @ParameterizedTest
@@ -257,17 +330,21 @@ public class InboundTransactionItemProcessorValidatorTest {
     public void processTransactionWithInvalidMccThrowsException(String mcc) {
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setMcc(mcc);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
         Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"12345", "3000", "203"})
     public void processTransactionWithValidMcc(String mcc) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setMcc(mcc);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(mcc, outbound.getMcc());
     }
 
     @ParameterizedTest
@@ -275,17 +352,21 @@ public class InboundTransactionItemProcessorValidatorTest {
     public void processTransactionWithInvalidVatThrowsException(String vat) {
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setVat(vat);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
         Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"15376371009", "DE256610065"})
     public void processTransactionWithValidVat(String vat) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setVat(vat);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(vat, outbound.getVat());
     }
 
     @ParameterizedTest
@@ -293,17 +374,21 @@ public class InboundTransactionItemProcessorValidatorTest {
     public void processTransactionWithInvalidPosTypeThrowsException(String posType) {
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setPosType(posType);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
         Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"00", "01"})
     public void processTransactionWithValidPosType(String posType) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setPosType(posType);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(posType, outbound.getPosType());
     }
 
     @ParameterizedTest
@@ -311,17 +396,21 @@ public class InboundTransactionItemProcessorValidatorTest {
     public void processTransactionWithInvalidParThrowsException(String par) {
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setPar(par);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
         Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"a70352ebab7fba1d20d8c667c37495a458d4", "0a3eb9af89ef1d6735e0489ed7d09f84a76fa2eb8e332a4e0e1d37ed7", STRING_LEN_255})
     public void processTransactionWithValidPar(String par) {
+        BDDMockito.doReturn(true).when(hpanStoreServiceMock).hasHpan(Mockito.eq(FAKE_ENROLLED_PAN));
+        BDDMockito.doReturn(FAKE_SALT).when(hpanStoreServiceMock).getSalt();
         InboundTransaction transaction = fakeInboundTransaction();
         transaction.setPar(par);
-        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, true);
-        processor.process(transaction);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(hpanStoreServiceMock, false);
+        InboundTransaction outbound = processor.process(transaction);
+        Assertions.assertNotNull(outbound);
+        Assertions.assertEquals(par, outbound.getPar());
     }
 
     private InboundTransaction fakeInboundTransaction() {
@@ -329,7 +418,7 @@ public class InboundTransactionItemProcessorValidatorTest {
                 .acquirerCode("001")
                 .operationType("00")
                 .circuitType("00")
-                .pan("pan123")
+                .pan(FAKE_ENROLLED_PAN)
                 .trxDate("2020-04-09T16:22:45.304+00:00")
                 .idTrxAcquirer("1")
                 .idTrxIssuer("0")


### PR DESCRIPTION
#### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR re-enables the correct handling of the MCC field. The field value was hardcoded to '0000' on output files during the cashback period but the intended functionality must be restored in the 1.1.0. 

#### List of Changes

<!--- Describe your changes in detail -->
- restore functionality of MCC field
- re-declared checked exception (seems the more correct correct)
- solved Sonarcloud smell by replacing string literal with constant

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- MCC field must be restored in order to ship the release 1.1.0

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

<!--- What types of tests have you developed? Put an `x` in all the boxes that apply: -->
- [x] Unit Tests
- [ ] Narrow Integration Tests
- [ ] Integration Tests
- [ ] System Tests
- [ ] Performance Tests
- [ ] User Acceptance Tests
- [ ] Smoke Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Documentation:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
