### PR TITLE
[RTD-31] Prevent processing same input filename twice

### DIFF
--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/PreventReprocessingFilenameAlreadySeenTasklet.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/PreventReprocessingFilenameAlreadySeenTasklet.java
@@ -42,7 +42,7 @@ public class PreventReprocessingFilenameAlreadySeenTasklet implements Tasklet {
     public RepeatStatus execute(StepContribution stepContribution, ChunkContext chunkContext)
         throws IOException {
         if (this.transactionWriterService.existFileChannelForFilename(storeService.getTargetInputFile())) {
-            throw new IOException();
+            throw new IOException("A file named " + storeService.getTargetInputFile() + " has already been processed in previous jobs!");
         } else {
             return RepeatStatus.FINISHED;
         }

--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/PreventReprocessingFilenameAlreadySeenTasklet.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/PreventReprocessingFilenameAlreadySeenTasklet.java
@@ -1,0 +1,41 @@
+package it.gov.pagopa.rtd.transaction_filter.batch.step.tasklet;
+
+import it.gov.pagopa.rtd.transaction_filter.service.StoreService;
+import it.gov.pagopa.rtd.transaction_filter.service.TransactionWriterService;
+import java.io.IOException;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+
+/**
+ * TODO
+ */
+@Data
+@Slf4j
+public class PreventReprocessingFilenameAlreadySeenTasklet implements Tasklet {
+
+    private StoreService storeService;
+    private TransactionWriterService transactionWriterService;
+
+    /**
+     * TODO
+     *
+     * @param stepContribution
+     * @param chunkContext
+     * @return the {@link Tasklet} execution status
+     */
+    @Override
+    public RepeatStatus execute(StepContribution stepContribution, ChunkContext chunkContext)
+        throws IOException {
+        if (this.transactionWriterService.existFileChannel(storeService.getTargetInputFile())) {
+            throw new IOException();
+        } else {
+            return RepeatStatus.FINISHED;
+        }
+    }
+
+}

--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/PreventReprocessingFilenameAlreadySeenTasklet.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/PreventReprocessingFilenameAlreadySeenTasklet.java
@@ -12,7 +12,16 @@ import org.springframework.batch.repeat.RepeatStatus;
 
 
 /**
- * TODO
+ * {@link Tasklet} implementation checking that the job's target input file
+ * hasn't been processed in previous jobs.
+ *
+ * The program keeps track of previous jobs only in memory, so it cannot
+ * prevent the reprocessing of a file that has been processed during a previous
+ * execution of the application.
+ *
+ * Also keep in mind that this tasklet relies exclusively on the filename, and
+ * ignores the content of the input files. To prevent that the same identical file
+ * but named differently will be processed twice look at the TransactionChecksumTasklet.
  */
 @Data
 @Slf4j
@@ -22,7 +31,8 @@ public class PreventReprocessingFilenameAlreadySeenTasklet implements Tasklet {
     private TransactionWriterService transactionWriterService;
 
     /**
-     * TODO
+     * Terminates with failure the current job if the filename of the target input file has been
+     * already processed in previous jobs.
      *
      * @param stepContribution
      * @param chunkContext
@@ -31,7 +41,7 @@ public class PreventReprocessingFilenameAlreadySeenTasklet implements Tasklet {
     @Override
     public RepeatStatus execute(StepContribution stepContribution, ChunkContext chunkContext)
         throws IOException {
-        if (this.transactionWriterService.existFileChannel(storeService.getTargetInputFile())) {
+        if (this.transactionWriterService.existFileChannelForFilename(storeService.getTargetInputFile())) {
             throw new IOException();
         } else {
             return RepeatStatus.FINISHED;

--- a/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/PreventReprocessingFilenameAlreadySeenTaskletTest.java
+++ b/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/PreventReprocessingFilenameAlreadySeenTaskletTest.java
@@ -1,0 +1,93 @@
+package it.gov.pagopa.rtd.transaction_filter.batch.step.tasklet;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import it.gov.pagopa.rtd.transaction_filter.service.StoreService;
+import it.gov.pagopa.rtd.transaction_filter.service.TransactionWriterService;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.batch.test.MetaDataInstanceFactory;
+
+
+public class PreventReprocessingFilenameAlreadySeenTaskletTest {
+
+    private final static String inputTrxFile = "CSTAR.99999.TRNLOG.20220204.094652.001.csv";
+
+    private ChunkContext chunkContext;
+    private StepExecution execution;
+
+    @Mock
+    private StoreService storeServiceMock;
+
+    @Mock
+    private TransactionWriterService transactionWriterServiceMock;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    public PreventReprocessingFilenameAlreadySeenTaskletTest(){
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @BeforeClass
+    public static void configTest() {
+        Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        root.setLevel(Level.INFO);
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        reset(storeServiceMock);
+        reset(transactionWriterServiceMock);
+
+        execution = MetaDataInstanceFactory.createStepExecution();
+        StepContext stepContext = new StepContext(execution);
+        chunkContext = new ChunkContext(stepContext);
+    }
+
+    @Test
+    public void shouldRaiseIOExceptionWhenFileChannelHasBeenOpenedBefore() throws IOException {
+        PreventReprocessingFilenameAlreadySeenTasklet tasklet = new PreventReprocessingFilenameAlreadySeenTasklet();
+        tasklet.setStoreService(storeServiceMock);
+        tasklet.setTransactionWriterService(transactionWriterServiceMock);
+
+        doReturn(inputTrxFile).when(storeServiceMock).getTargetInputFile();
+        doReturn(true).when(transactionWriterServiceMock).existFileChannelForFilename(inputTrxFile);
+
+        expectedException.expect(IOException.class);
+        tasklet.execute(new StepContribution(execution), chunkContext);
+
+        verify(storeServiceMock, Mockito.times(1)).getTargetInputFile();
+    }
+
+    @Test
+    public void shouldReturnFinishedWhenFileChannelHasntBeenOpenedBefore() throws IOException {
+        PreventReprocessingFilenameAlreadySeenTasklet tasklet = new PreventReprocessingFilenameAlreadySeenTasklet();
+        tasklet.setStoreService(storeServiceMock);
+        tasklet.setTransactionWriterService(transactionWriterServiceMock);
+
+        doReturn(inputTrxFile).when(storeServiceMock).getTargetInputFile();
+        doReturn(false).when(transactionWriterServiceMock).existFileChannelForFilename(inputTrxFile);
+
+        tasklet.execute(new StepContribution(execution), chunkContext);
+
+        verify(storeServiceMock, Mockito.times(1)).getTargetInputFile();
+        verify(transactionWriterServiceMock, Mockito.times(1)).existFileChannelForFilename(inputTrxFile);
+    }
+}

--- a/core/src/main/java/it/gov/pagopa/rtd/transaction_filter/service/TransactionWriterService.java
+++ b/core/src/main/java/it/gov/pagopa/rtd/transaction_filter/service/TransactionWriterService.java
@@ -4,7 +4,7 @@ public interface TransactionWriterService {
 
     void openFileChannel(String filename);
 
-    boolean existFileChannel(String filename);
+    boolean existFileChannelForFilename(String filename);
 
     void write(String filename, String content);
 

--- a/core/src/main/java/it/gov/pagopa/rtd/transaction_filter/service/TransactionWriterService.java
+++ b/core/src/main/java/it/gov/pagopa/rtd/transaction_filter/service/TransactionWriterService.java
@@ -4,6 +4,8 @@ public interface TransactionWriterService {
 
     void openFileChannel(String filename);
 
+    boolean existFileChannel(String filename);
+
     void write(String filename, String content);
 
     void closeAll();

--- a/core/src/main/java/it/gov/pagopa/rtd/transaction_filter/service/TransactionWriterServiceImpl.java
+++ b/core/src/main/java/it/gov/pagopa/rtd/transaction_filter/service/TransactionWriterServiceImpl.java
@@ -37,8 +37,13 @@ public class TransactionWriterServiceImpl implements TransactionWriterService {
     }
 
     @Override
-    public synchronized boolean existFileChannel(String filename) {
-        return fileChannelMap.containsKey(filename);
+    public synchronized boolean existFileChannelForFilename(String filename) {
+        for (String key : fileChannelMap.keySet()) {
+            if (key.contains(filename)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @SneakyThrows

--- a/core/src/main/java/it/gov/pagopa/rtd/transaction_filter/service/TransactionWriterServiceImpl.java
+++ b/core/src/main/java/it/gov/pagopa/rtd/transaction_filter/service/TransactionWriterServiceImpl.java
@@ -36,6 +36,11 @@ public class TransactionWriterServiceImpl implements TransactionWriterService {
 
     }
 
+    @Override
+    public synchronized boolean existFileChannel(String filename) {
+        return fileChannelMap.containsKey(filename);
+    }
+
     @SneakyThrows
     @Override
     public void write(String filename, String content) {

--- a/core/src/test/java/it/gov/pagopa/rtd/transaction_filter/service/TransactionWriterServiceTest.java
+++ b/core/src/test/java/it/gov/pagopa/rtd/transaction_filter/service/TransactionWriterServiceTest.java
@@ -1,0 +1,39 @@
+package it.gov.pagopa.rtd.transaction_filter.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedWriter;
+import java.util.HashMap;
+import java.util.TreeSet;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TransactionWriterServiceTest {
+
+    private final static String inputTrxFileNotSeen = "CSTAR.99999.TRNLOG.20220204.094652.001.csv";
+    private final static String inputTrxFileSeen = "CSTAR.99999.TRNLOG.20220504.141151.001.csv";
+    private final static String filePathPrefix = "/workdir/logs/20220505153114123_Rtd__ErrorRecords_";
+
+    private TransactionWriterService transactionWriterService;
+
+    @Before
+    public void setUp() {
+        HashMap<String, BufferedWriter> fileChannelMapMock = new HashMap<>();
+        fileChannelMapMock.put(filePathPrefix + "CSTAR.99999.TRNLOG.20220505.132817.001.csv", null);
+        fileChannelMapMock.put(filePathPrefix + "CSTAR.99999.TRNLOG.20220504.141151.001.csv", null);
+        fileChannelMapMock.put(filePathPrefix + "CSTAR.99999.TRNLOG.20220503.132022.001.csv", null);
+        transactionWriterService = new TransactionWriterServiceImpl(fileChannelMapMock, new TreeSet<>());
+    }
+
+    @Test
+    public void shouldReturnFalseWhenFileChannelDoesNotExist() {
+        assertFalse(transactionWriterService.existFileChannelForFilename(inputTrxFileNotSeen));
+    }
+
+    @Test
+    public void shouldReturnTrueWhenFileChannelExists() {
+        assertTrue(transactionWriterService.existFileChannelForFilename(inputTrxFileSeen));
+    }
+
+}


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds a step to the batch process that verifies if the current input file, solely given its filename, has been processed in previous jobs. If so, the current job exit immediately and a custom exception is thrown.

#### List of Changes

<!--- Describe your changes in detail -->
- Add new Tasklet responsible for checking current input filename against opened file channels

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- The use case was, by accident, already implemented, but the error wasn't gracefully handled

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
