### PR TITLE
[TAE-37] Replace fake abi in trx process

### DIFF
--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/processor/TransactionAggregationReaderProcessor.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/processor/TransactionAggregationReaderProcessor.java
@@ -40,7 +40,7 @@ public class TransactionAggregationReaderProcessor implements ItemProcessor<Inbo
 
         AggregationKey key = new AggregationKey();
         key.setAcquirerCode(storeService.flyweightAcquirerCode(inboundTransaction.getAcquirerCode()));
-        key.setAcquirerId(storeService.flyweightAcquirerId(inboundTransaction.getAcquirerId()));
+        key.setAcquirerId(storeService.flyweightAcquirerIdToFiscalCode(inboundTransaction.getAcquirerId()));
         key.setMerchantId(inboundTransaction.getMerchantId());
         key.setTerminalId(inboundTransaction.getTerminalId());
         key.setFiscalCode(inboundTransaction.getFiscalCode());

--- a/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/TransactionFilterBatchTest.java
+++ b/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/TransactionFilterBatchTest.java
@@ -1,26 +1,44 @@
 package it.gov.pagopa.rtd.transaction_filter.batch;
 
+import static org.springframework.transaction.annotation.Propagation.NOT_SUPPORTED;
+
 import it.gov.pagopa.rtd.transaction_filter.batch.config.TestConfig;
 import it.gov.pagopa.rtd.transaction_filter.batch.encryption.EncryptUtil;
 import it.gov.pagopa.rtd.transaction_filter.connector.AbiToFiscalCodeRestClient;
 import it.gov.pagopa.rtd.transaction_filter.service.StoreService;
 import it.gov.pagopa.rtd.transaction_filter.service.TransactionWriterService;
 import it.gov.pagopa.rtd.transaction_filter.service.TransactionWriterServiceImpl;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
-import org.junit.Test;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Assert;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.mockito.*;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParametersBuilder;
@@ -37,21 +55,13 @@ import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.nio.file.Files;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.springframework.transaction.annotation.Propagation.NOT_SUPPORTED;
 
 @RunWith(SpringRunner.class)
 @SpringBatchTest
@@ -107,6 +117,7 @@ import static org.springframework.transaction.annotation.Propagation.NOT_SUPPORT
                 "batchConfiguration.TransactionFilterBatch.transactionFilter.readers.listener.writerPoolSize=5"
         }
 )
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class TransactionFilterBatchTest {
 
     @Autowired
@@ -151,53 +162,30 @@ public class TransactionFilterBatchTest {
         tempFolder.delete();
     }
 
+    @After
+    public void cleanUp() {
+        jobRepositoryTestUtils.removeJobExecutions();
+    }
+
     @SneakyThrows
     @Test
     public void jobExecutionProducesExpectedFiles() {
 
-        String publicKeyPath = "file:/" + this.getClass().getResource("/test-encrypt").getFile() + "/publicKey.asc";
-        Resource publicKeyResource = resolver.getResource(publicKeyPath);
-        FileInputStream publicKeyFilePathIS = new FileInputStream(publicKeyResource.getFile());
-        String publicKey = IOUtils.toString(publicKeyFilePathIS);
+        String publicKey = createPublicKey();
 
         BDDMockito.doReturn(publicKey).when(storeServiceSpy).getKey("pagopa");
 
-        tempFolder.newFolder("hpan");
-        File panPgp = tempFolder.newFile("hpan/pan.pgp");
+        createPanPGP();
 
-        FileOutputStream panPgpFOS = new FileOutputStream(panPgp);
-
-        EncryptUtil.encryptFile(panPgpFOS,
-                this.getClass().getResource("/test-encrypt/pan").getFile() + "/pan.csv",
-                EncryptUtil.readPublicKey(
-                        this.getClass().getResourceAsStream("/test-encrypt/publicKey.asc")),
-                false, false);
-
-        panPgpFOS.close();
-
-        File outputFileTrn = new File(resolver.getResource("classpath:/test-encrypt/output")
-                .getFile().getAbsolutePath() + "/CSTAR.99999.TRNLOG.20220204.094652.001.csv");
-
-        if (!outputFileTrn.exists()) {
-            outputFileTrn.createNewFile();
-        }
-
-        File outputFileAde = new File(resolver.getResource("classpath:/test-encrypt/output")
-            .getFile().getAbsolutePath() + "/ADE.99999.TRNLOG.20220204.094652.001.csv");
-
-        if (!outputFileAde.exists()) {
-            outputFileAde.createNewFile();
-        }
+        File outputFileTrn = createTrnOutputFile();
+        File outputFileAde = createAdeOutputFile();
 
         // Check that the job exited with the right exit status
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(new JobParametersBuilder()
                 .addDate("startDateTime", new Date())
                 .toJobParameters());
 
-        // IMPORTANT: file handlers used by listeners must be closed explicitly, otherwise
-        // being unbuffered the log files will be created but there won't be any content inside
-        TransactionWriterService transactionWriterService = context.getBean(TransactionWriterServiceImpl.class);
-        transactionWriterService.closeAll();
+        closeAllFileChannels();
 
         Assert.assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
 
@@ -207,44 +195,26 @@ public class TransactionFilterBatchTest {
         BDDMockito.verify(storeServiceSpy, Mockito.times(2)).getKey(Mockito.any());
 
         // Check that output folder contains expected files, and only those
-        Collection<File> outputPgpFiles = FileUtils.listFiles(
-                resolver.getResources("classpath:/test-encrypt/output")[0].getFile(), new String[]{"pgp"}, false);
+        Collection<File> outputPgpFiles = getOutputPgpFiles();
         Assert.assertEquals(2, outputPgpFiles.size());
 
-        Set<String> outputPgpFilenames = outputPgpFiles.stream().map(p -> p.getName()).collect(Collectors.toSet());
-        Set<String> expectedPgpFilenames = new HashSet<>();
-        expectedPgpFilenames.add("CSTAR.99999.TRNLOG.20220204.094652.001.csv.pgp");
-        expectedPgpFilenames.add("ADE.99999.TRNLOG.20220204.094652.001.csv.pgp");
+        Set<String> outputPgpFilenames = outputPgpFiles.stream().map(File::getName).collect(Collectors.toSet());
+        Set<String> expectedPgpFilenames = getExpectedPgpFilenames();
         Assert.assertEquals(expectedPgpFilenames, outputPgpFilenames);
 
-        Collection<File> outputCsvFiles = FileUtils.listFiles(
-            resolver.getResources("classpath:/test-encrypt/output")[0].getFile(), new String[]{"csv"}, false);
+        Collection<File> outputCsvFiles = getOutputCsvFiles();
         Assert.assertEquals(2, outputCsvFiles.size());
 
-        Set<String> outputCsvFilenames = outputCsvFiles.stream().map(p -> p.getName()).collect(Collectors.toSet());
-        Set<String> expectedCsvFilenames = new HashSet<>();
-        expectedCsvFilenames.add("CSTAR.99999.TRNLOG.20220204.094652.001.csv");
-        expectedCsvFilenames.add("ADE.99999.TRNLOG.20220204.094652.001.csv");
+        Set<String> outputCsvFilenames = outputCsvFiles.stream().map(File::getName).collect(Collectors.toSet());
+        Set<String> expectedCsvFilenames = getExpectedCsvFileNames();
         Assert.assertEquals(expectedCsvFilenames, outputCsvFilenames);
 
         List<String> outputFileTrnContent = Files.readAllLines(outputFileTrn.toPath().toAbsolutePath());
         List<String> outputFileAdeContent = Files.readAllLines(outputFileAde.toPath().toAbsolutePath());
 
         // Check that output files contain expected lines
-        Set<String> expectedOutputFileTrnContent = new HashSet<>();
-        expectedOutputFileTrnContent.add("#sha256sum:8bca0fdabf06e1c30b716224c67a5753ac5d999cf6a375ac7adba16f725f2046");
-        expectedOutputFileTrnContent.add("99999;00;00;28aa47c8c6cd1a6b0a86ebe18471295796c88269868825b4cd41f94f0a07e88e;03/20/2020 10:50:33;1111111111;5555;;1111;978;22222;0000;1;000002;5422;fis123;12345678901;00;");
-        expectedOutputFileTrnContent.add("99999;00;01;e2df0a82ac0aa12921c398e1eba9119772db868650ebef22b8919fa0fb7642ed;03/20/2020 11:23:00;333333333;7777;;3333;978;4444;0000;1;000002;5422;fis123;12345678901;00;");
-        expectedOutputFileTrnContent.add("99999;01;00;805f89015f85948f7d7bdd57a0a81e4cd95fc81bdd1195a69c4ab139f0ebed7b;03/20/2020 11:04:53;2222222222;6666;;2222;978;3333;0000;1;000002;5422;fis123;12345678901;00;par2");
-
-        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-        String transmissionDate = OffsetDateTime.now().format(fmt);
-
-        Set<String> expectedOutputFileAdeContent = new HashSet<>();
-        expectedOutputFileAdeContent.add("#sha256sum:8bca0fdabf06e1c30b716224c67a5753ac5d999cf6a375ac7adba16f725f2046");
-        expectedOutputFileAdeContent.add("99999;00;" + transmissionDate + ";03/20/2020;2;6666;978;4444;0000;1;fis123;12345678901;00");
-        expectedOutputFileAdeContent.add("99999;01;" + transmissionDate + ";03/20/2020;1;2222;978;3333;0000;1;fis123;12345678901;00");
-        expectedOutputFileAdeContent.add("99999;00;" + transmissionDate + ";03/20/2020;1;1111;978;22222;0000;1;fis123;12345678901;00");
+        Set<String> expectedOutputFileTrnContent = getExpectedTrnOutputFileContent();
+        Set<String> expectedOutputFileAdeContent = getExpectedAdeOutputFileContent();
 
         Assert.assertEquals(expectedOutputFileTrnContent, new HashSet<>(outputFileTrnContent));
         Assert.assertEquals("#sha256sum:8bca0fdabf06e1c30b716224c67a5753ac5d999cf6a375ac7adba16f725f2046",
@@ -318,6 +288,29 @@ public class TransactionFilterBatchTest {
 
     @SneakyThrows
     @Test
+    public void whenAbiToFiscalCodeMapIsSetThenOutputMustHaveConvertedAcquirerId() {
+        String publicKey = createPublicKey();
+
+        BDDMockito.doReturn(publicKey).when(storeServiceSpy).getKey("pagopa");
+        BDDMockito.doReturn(createAbiToFiscalCodeMap()).when(abiToFiscalCodeRestClient)
+            .getFakeAbiToFiscalCodeMap();
+
+        createPanPGP();
+        File outputFileAde = createAdeOutputFile();
+
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob(new JobParametersBuilder()
+            .addDate("startDateTime", new Date())
+            .toJobParameters());
+        Assert.assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
+
+        List<String> outputFileAdeContent = Files.readAllLines(outputFileAde.toPath().toAbsolutePath());
+        Set<String> expectedOutputFileAdeContent = getExpectedAdeOutputFileContentWithAbiConverted();
+
+        Assert.assertEquals(expectedOutputFileAdeContent, new HashSet<>(outputFileAdeContent));
+    }
+
+    @SneakyThrows
+    @Test
     public void jobExecutionFails() {
 
         tempFolder.newFolder("hpan");
@@ -337,4 +330,124 @@ public class TransactionFilterBatchTest {
         BDDMockito.verify(storeServiceSpy, Mockito.times(0)).store(Mockito.any());
 
     }
+
+    private String createPublicKey() throws IOException {
+        String publicKeyPath = "file:/" + Objects.requireNonNull(
+            this.getClass().getResource("/test-encrypt")).getFile() + "/publicKey.asc";
+        Resource publicKeyResource = resolver.getResource(publicKeyPath);
+        FileInputStream publicKeyFilePathIS = new FileInputStream(publicKeyResource.getFile());
+        return IOUtils.toString(publicKeyFilePathIS);
+    }
+
+    @SneakyThrows
+    private void createPanPGP() {
+        tempFolder.newFolder("hpan");
+        File panPgp = tempFolder.newFile("hpan/pan.pgp");
+
+        FileOutputStream panPgpFOS = new FileOutputStream(panPgp);
+
+        EncryptUtil.encryptFile(panPgpFOS,
+            Objects.requireNonNull(this.getClass().getResource("/test-encrypt/pan")).getFile() + "/pan.csv",
+            EncryptUtil.readPublicKey(
+                this.getClass().getResourceAsStream("/test-encrypt/publicKey.asc")),
+            false, false);
+
+        panPgpFOS.close();
+    }
+
+    private Map<String, String> createAbiToFiscalCodeMap() {
+        Map<String, String> abiToFiscalCodeMap = new HashMap<>();
+        abiToFiscalCodeMap.put("4444", "fiscalCode");
+        return abiToFiscalCodeMap;
+    }
+
+    @SneakyThrows
+    private File createAdeOutputFile() {
+        File outputFileAde = new File(resolver.getResource("classpath:/test-encrypt/output")
+            .getFile().getAbsolutePath() + "/ADE.99999.TRNLOG.20220204.094652.001.csv");
+
+        outputFileAde.createNewFile();
+        return outputFileAde;
+    }
+
+    @SneakyThrows
+    private File createTrnOutputFile() {
+        File outputFileTrn = new File(resolver.getResource("classpath:/test-encrypt/output")
+            .getFile().getAbsolutePath() + "/CSTAR.99999.TRNLOG.20220204.094652.001.csv");
+
+        outputFileTrn.createNewFile();
+        return outputFileTrn;
+    }
+
+    private void closeAllFileChannels() {
+        // IMPORTANT: file handlers used by listeners must be closed explicitly, otherwise
+        // being unbuffered the log files will be created but there won't be any content inside
+        TransactionWriterService transactionWriterService = context.getBean(TransactionWriterServiceImpl.class);
+        transactionWriterService.closeAll();
+    }
+
+    @SneakyThrows
+    private Collection<File> getOutputPgpFiles() {
+        return FileUtils.listFiles(
+            resolver.getResources("classpath:/test-encrypt/output")[0].getFile(), new String[]{"pgp"}, false);
+    }
+
+    private Set<String> getExpectedPgpFilenames() {
+        Set<String> expectedPgpFilenames = new HashSet<>();
+        expectedPgpFilenames.add("CSTAR.99999.TRNLOG.20220204.094652.001.csv.pgp");
+        expectedPgpFilenames.add("ADE.99999.TRNLOG.20220204.094652.001.csv.pgp");
+        return expectedPgpFilenames;
+    }
+
+    @SneakyThrows
+    private Collection<File> getOutputCsvFiles() {
+        return FileUtils.listFiles(
+            resolver.getResources("classpath:/test-encrypt/output")[0].getFile(), new String[]{"csv"}, false);
+    }
+
+    private Set<String> getExpectedCsvFileNames() {
+        Set<String> expectedCsvFilenames = new HashSet<>();
+        expectedCsvFilenames.add("CSTAR.99999.TRNLOG.20220204.094652.001.csv");
+        expectedCsvFilenames.add("ADE.99999.TRNLOG.20220204.094652.001.csv");
+
+        return expectedCsvFilenames;
+    }
+
+    private Set<String> getExpectedTrnOutputFileContent() {
+        Set<String> expectedOutputFileTrnContent = new HashSet<>();
+        expectedOutputFileTrnContent.add("#sha256sum:8bca0fdabf06e1c30b716224c67a5753ac5d999cf6a375ac7adba16f725f2046");
+        expectedOutputFileTrnContent.add("99999;00;00;28aa47c8c6cd1a6b0a86ebe18471295796c88269868825b4cd41f94f0a07e88e;03/20/2020 10:50:33;1111111111;5555;;1111;978;22222;0000;1;000002;5422;fis123;12345678901;00;");
+        expectedOutputFileTrnContent.add("99999;00;01;e2df0a82ac0aa12921c398e1eba9119772db868650ebef22b8919fa0fb7642ed;03/20/2020 11:23:00;333333333;7777;;3333;978;4444;0000;1;000002;5422;fis123;12345678901;00;");
+        expectedOutputFileTrnContent.add("99999;01;00;805f89015f85948f7d7bdd57a0a81e4cd95fc81bdd1195a69c4ab139f0ebed7b;03/20/2020 11:04:53;2222222222;6666;;2222;978;3333;0000;1;000002;5422;fis123;12345678901;00;par2");
+        return expectedOutputFileTrnContent;
+    }
+
+    private Set<String> getExpectedAdeOutputFileContentWithAbiConverted() {
+        String transmissionDate = getDateFormattedAsString();
+
+        Set<String> expectedOutputFileAdeContent = new HashSet<>();
+        expectedOutputFileAdeContent.add("#sha256sum:8bca0fdabf06e1c30b716224c67a5753ac5d999cf6a375ac7adba16f725f2046");
+        expectedOutputFileAdeContent.add("99999;00;" + transmissionDate + ";03/20/2020;2;6666;978;fiscalCode;0000;1;fis123;12345678901;00");
+        expectedOutputFileAdeContent.add("99999;01;" + transmissionDate + ";03/20/2020;1;2222;978;3333;0000;1;fis123;12345678901;00");
+        expectedOutputFileAdeContent.add("99999;00;" + transmissionDate + ";03/20/2020;1;1111;978;22222;0000;1;fis123;12345678901;00");
+
+        return expectedOutputFileAdeContent;
+    }
+
+    private Set<String> getExpectedAdeOutputFileContent() {
+        String transmissionDate = getDateFormattedAsString();
+
+        Set<String> expectedOutputFileAdeContent = new HashSet<>();
+        expectedOutputFileAdeContent.add("#sha256sum:8bca0fdabf06e1c30b716224c67a5753ac5d999cf6a375ac7adba16f725f2046");
+        expectedOutputFileAdeContent.add("99999;00;" + transmissionDate + ";03/20/2020;2;6666;978;4444;0000;1;fis123;12345678901;00");
+        expectedOutputFileAdeContent.add("99999;01;" + transmissionDate + ";03/20/2020;1;2222;978;3333;0000;1;fis123;12345678901;00");
+        expectedOutputFileAdeContent.add("99999;00;" + transmissionDate + ";03/20/2020;1;1111;978;22222;0000;1;fis123;12345678901;00");
+
+        return expectedOutputFileAdeContent;
+    }
+    private String getDateFormattedAsString() {
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return OffsetDateTime.now().format(fmt);
+    }
+
 }


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds the actual replacement of field acquirer id in case the fake ABI is mapped to a fiscal code.

#### List of Changes

<!--- Describe your changes in detail -->
- Replace of abi with mapped fiscal code (if the entry exists, do nothing otherwise)
- Add unit test of a complete job run with a `abiToFiscalCode` map set. Assert on the output file.
- Refactor an existing unit test

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Replace a fake abi with the correct fiscal code during the processing step of transactions input file. 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
