### PR TITLE
[RTD-474] Improve validation errors logging on ADE

### DIFF
--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/TransactionFilterStep.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/TransactionFilterStep.java
@@ -433,6 +433,7 @@ public class TransactionFilterStep {
             .noRetry(ConstraintViolationException.class)
             .noRollback(ConstraintViolationException.class)
             .listener(transactionAdeItemReaderListener(transactionWriterService, executionDate))
+            .listener(transactionAdeItemProcessListener(transactionWriterService, executionDate))
             .listener(transactionAdeStepListener(transactionWriterService, executionDate))
             .taskExecutor(batchConfig.readerTaskExecutor())
             .build();
@@ -551,6 +552,22 @@ public class TransactionFilterStep {
         transactionItemProcessListener.setEnableAfterProcessFileLogging(enableAfterProcessFileLogging);
         transactionItemProcessListener.setTransactionWriterService(transactionWriterService);
         transactionItemProcessListener.setPrefix(LOG_PREFIX_TRN);
+        return transactionItemProcessListener;
+    }
+
+    @Bean
+    public TransactionItemProcessListener transactionAdeItemProcessListener(
+        TransactionWriterService transactionWriterService, String executionDate) {
+        TransactionItemProcessListener transactionItemProcessListener = new TransactionItemProcessListener();
+        transactionItemProcessListener.setExecutionDate(executionDate);
+        transactionItemProcessListener.setErrorTransactionsLogsPath(transactionLogsPath);
+        transactionItemProcessListener.setEnableAfterProcessLogging(enableAfterProcessLogging);
+        transactionItemProcessListener.setLoggingFrequency(loggingFrequency);
+        transactionItemProcessListener.setEnableOnErrorFileLogging(enableOnProcessErrorFileLogging);
+        transactionItemProcessListener.setEnableOnErrorLogging(enableOnProcessErrorLogging);
+        transactionItemProcessListener.setEnableAfterProcessFileLogging(enableAfterProcessFileLogging);
+        transactionItemProcessListener.setTransactionWriterService(transactionWriterService);
+        transactionItemProcessListener.setPrefix(LOG_PREFIX_ADE);
         return transactionItemProcessListener;
     }
 

--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/listener/TransactionItemProcessListener.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/listener/TransactionItemProcessListener.java
@@ -78,8 +78,8 @@ public class TransactionItemProcessListener implements ItemProcessListener<Inbou
 
     public void onProcessError(InboundTransaction item, Exception throwable) {
 
-        if (transactionWriterService.hasErrorHpan(item.getFilename()
-                .concat(String.valueOf(item.getLineNumber())))) {
+        if (Boolean.TRUE.equals(transactionWriterService.hasErrorHpan(item.getFilename()
+                .concat(String.valueOf(item.getLineNumber()))))) {
             return;
         }
 
@@ -100,12 +100,12 @@ public class TransactionItemProcessListener implements ItemProcessListener<Inbou
 
         if (Boolean.TRUE.equals(enableOnErrorFileLogging)) {
             try {
-                String filename = item.getFilename().replace("\\\\", "/");
+                String filename = item.getFilename().replace("\\", "/");
                 String[] fileArr = filename.split("/");
                 transactionWriterService.write(resolver.getResource(errorTransactionsLogsPath)
                         .getFile().getAbsolutePath()
                         .concat("/".concat(executionDate))
-                        + "_" + prefix + "_ErrorRecords_"+fileArr[fileArr.length-1]+".csv",buildCsv(item));
+                        + "_" + prefix + "_ErrorRecords_" + fileArr[fileArr.length-1], buildCsv(item));
             } catch (Exception e) {
                 log.error(e.getMessage(), e);
             }

--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/listener/TransactionItemProcessListener.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/listener/TransactionItemProcessListener.java
@@ -130,7 +130,7 @@ public class TransactionItemProcessListener implements ItemProcessListener<Inbou
                 .concat(Optional.ofNullable(inboundTransaction.getIdTrxAcquirer()).orElse("")).concat(";")
                 .concat(Optional.ofNullable(inboundTransaction.getIdTrxIssuer()).orElse("")).concat(";")
                 .concat(Optional.ofNullable(inboundTransaction.getCorrelationId()).orElse("")).concat(";")
-                .concat(inboundTransaction.getAmount() != null ? inboundTransaction.getAmount().toString() : "").concat(";")
+                .concat(Optional.ofNullable(inboundTransaction.getAmount()).orElse(0L).toString()).concat(";")
                 .concat(Optional.ofNullable(inboundTransaction.getAmountCurrency()).orElse("")).concat(";")
                 .concat(Optional.ofNullable(inboundTransaction.getAcquirerId()).orElse("")).concat(";")
                 .concat(Optional.ofNullable(inboundTransaction.getMerchantId()).orElse("")).concat(";")

--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/processor/TransactionAggregationReaderProcessor.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/processor/TransactionAggregationReaderProcessor.java
@@ -58,7 +58,8 @@ public class TransactionAggregationReaderProcessor implements ItemProcessor<Inbo
             log.warn("Dirty data found on either VAT or POS type fields at line {}", inboundTransaction.getLineNumber());
         }
 
-        // Return null since we'll bound to a dummy writer
-        return null;
+        // Return the input transaction since it's needed by the listener to log validation errors
+        // The writer is dummy and do not require any value
+        return inboundTransaction;
     }
 }

--- a/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/config/LoggerRule.java
+++ b/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/config/LoggerRule.java
@@ -3,6 +3,7 @@ package it.gov.pagopa.rtd.transaction_filter.batch.config;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import java.util.List;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -35,5 +36,9 @@ public class LoggerRule implements TestRule {
         listAppender.stop();
         listAppender.list.clear();
         logger.detachAppender(listAppender);
+    }
+
+    public List<ILoggingEvent> getLogList() {
+        return listAppender.list;
     }
 }

--- a/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/listener/TransactionItemProcessListenerTest.java
+++ b/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/listener/TransactionItemProcessListenerTest.java
@@ -1,8 +1,17 @@
 package it.gov.pagopa.rtd.transaction_filter.batch.step.listener;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import it.gov.pagopa.rtd.transaction_filter.batch.config.LoggerRule;
 import it.gov.pagopa.rtd.transaction_filter.batch.model.InboundTransaction;
 import it.gov.pagopa.rtd.transaction_filter.service.TransactionWriterService;
+import it.gov.pagopa.rtd.transaction_filter.validator.ValidatorConfig;
+import java.io.File;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validator;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.*;
@@ -12,10 +21,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
-
-import java.io.File;
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 
 @Slf4j
 public class TransactionItemProcessListenerTest {
@@ -130,6 +135,70 @@ public class TransactionItemProcessListenerTest {
 
         BDDMockito.verify(transactionWriterService, Mockito.times(0)).write(Mockito.any(),Mockito.any());
 
+    }
+
+    @SneakyThrows
+    @Test
+    public void whenOnProcessErrorGivenValidationErrorThenLogErrors() {
+        File folder = tempFolder.newFolder("testProcess");
+
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS");
+        String executionDate = OffsetDateTime.now().format(fmt);
+
+        TransactionItemProcessListener transactionItemProcessListener = new TransactionItemProcessListener();
+        transactionItemProcessListener.setExecutionDate(executionDate);
+        transactionItemProcessListener.setResolver(new PathMatchingResourcePatternResolver());
+        transactionItemProcessListener.setErrorTransactionsLogsPath("file:/"+folder.getAbsolutePath());
+        transactionItemProcessListener.setEnableOnErrorLogging(true);
+        transactionItemProcessListener.setEnableAfterProcessLogging(true);
+        transactionItemProcessListener.setEnableOnErrorFileLogging(false);
+        transactionItemProcessListener.setLoggingFrequency(1L);
+        transactionItemProcessListener.setTransactionWriterService(transactionWriterService);
+        transactionItemProcessListener.onProcessError(
+            InboundTransaction.builder().filename("test").lineNumber(1).build(),
+            getValidationException());
+
+        BDDMockito.verify(transactionWriterService, Mockito.times(0)).write(Mockito.any(),Mockito.any());
+        boolean isLogPresent = loggerRule.getLogList().stream().map(ILoggingEvent::getFormattedMessage).anyMatch(this::getValidationError);
+        assertThat(isLogPresent).isTrue();
+    }
+
+    @SneakyThrows
+    @Test
+    public void whenOnProcessErrorGivenValidationErrorAndErrorLogFlagDisabledThenDoNothing() {
+        File folder = tempFolder.newFolder("testProcess");
+
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS");
+        String executionDate = OffsetDateTime.now().format(fmt);
+
+        TransactionItemProcessListener transactionItemProcessListener = new TransactionItemProcessListener();
+        transactionItemProcessListener.setExecutionDate(executionDate);
+        transactionItemProcessListener.setResolver(new PathMatchingResourcePatternResolver());
+        transactionItemProcessListener.setErrorTransactionsLogsPath("file:/"+folder.getAbsolutePath());
+        transactionItemProcessListener.setEnableOnErrorLogging(false);
+        transactionItemProcessListener.setEnableAfterProcessLogging(true);
+        transactionItemProcessListener.setEnableOnErrorFileLogging(false);
+        transactionItemProcessListener.setLoggingFrequency(1L);
+        transactionItemProcessListener.setTransactionWriterService(transactionWriterService);
+        transactionItemProcessListener.onProcessError(
+            InboundTransaction.builder().filename("test").lineNumber(1).build(),
+            getValidationException());
+
+        BDDMockito.verify(transactionWriterService, Mockito.times(0)).write(Mockito.any(),Mockito.any());
+        boolean isLogPresent = loggerRule.getLogList().stream().map(ILoggingEvent::getFormattedMessage).anyMatch(this::getValidationError);
+        assertThat(isLogPresent).isFalse();
+    }
+
+    private ConstraintViolationException getValidationException() {
+        ValidatorConfig validatorConfig = new ValidatorConfig();
+        Validator validator = validatorConfig.getValidator();
+        InboundTransaction inboundTransaction = InboundTransaction.builder().filename("test")
+            .amountCurrency("wrongValue").lineNumber(1).build();
+        return new ConstraintViolationException(validator.validate(inboundTransaction));
+    }
+
+    private boolean getValidationError(String logMessage) {
+        return logMessage.contains("Error during record validation at line: 1, on field: amountCurrency, value: wrongValue");
     }
 
     @After


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add the logging during the ade file processing, in particular the validation errors. Plus 

#### List of Changes

<!--- Describe your changes in detail -->
- Add processor listener to ade
- Minor fix on file log naming
- Minor improvement on code readability

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The acquirers needs a way to understand easily what went wrong during the file processing therefore it is required a better logging. The validation errors have been added to the logs to let the acquirers know if the file presents any problem.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
