### PR TITLE
[RTD-473] improve clearness of sender code uniqueness check log

### DIFF
--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/EnforceSenderCodeUniquenessTasklet.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/EnforceSenderCodeUniquenessTasklet.java
@@ -35,17 +35,20 @@ public class EnforceSenderCodeUniquenessTasklet implements Tasklet {
     public RepeatStatus execute(StepContribution stepContribution, ChunkContext chunkContext)
         throws IOException {
         SenderCodeFlyweight senderCodeFlyweight = storeService.getSenderCodeFlyweight();
-        if (senderCodeFlyweight.cacheSize() != 1) {
-            throw new IOException("Sender code is not unique within file content (n of distinct values: " + senderCodeFlyweight.cacheSize() + ")");
-        } else {
-            Collection<SenderCode> senderCodes = senderCodeFlyweight.values();
-            SenderCode code = senderCodes.iterator().next();
-            if (!code.getCode().equals(storeService.getTargetInputFileAbiPart())) {
-                throw new IOException("Sender code is not unique between file content and file name");
-            } else {
-                return RepeatStatus.FINISHED;
-            }
+        if (senderCodeFlyweight.cacheSize() == 0) {
+            throw new IOException("Input file is empty or every rows presents parsing/validation errors. Please check the logs above.");
         }
+        if (senderCodeFlyweight.cacheSize() > 1) {
+            throw new IOException("Sender code is not unique within file content (n of distinct values: " + senderCodeFlyweight.cacheSize() + ")");
+        }
+
+        Collection<SenderCode> senderCodes = senderCodeFlyweight.values();
+        SenderCode code = senderCodes.iterator().next();
+        if (!code.getCode().equals(storeService.getTargetInputFileAbiPart())) {
+            throw new IOException("Sender code is not unique between file content and file name");
+        }
+
+        return RepeatStatus.FINISHED;
     }
 
 }


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to improve the log clearness of the sender code uniqueness check. 

#### List of Changes

<!--- Describe your changes in detail -->
- Add log message in sender code check

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When the input file is empty or all records have been discarded during processing, the sender code uniqueness check fails and shows an unclear log message. The two use cases mentioned before deserve a dedicated log message to improve the understandability of batch service processes. 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
