### PR TITLE
[RTD-402] parametrize url salt and set v2 endpoint by default

### DIFF
--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -115,7 +115,7 @@ rest-client:
     api:
       key: ${HPAN_SERVICE_API_KEY:test}
     list:
-      url: /rtd/payment-instrument-manager/${ACQ_BATCH_HPAN_LIST_URL:hashed-pans}
+      url: /rtd/payment-instrument-manager/${ACQ_BATCH_HPAN_LIST_URL:v2/hashed-pans}
       attemptExtraction: ${ACQ_BATCH_HPAN_LIST_ATTEMPT_EXTRACT:true}
       checksumValidation: ${ACQ_BATCH_HPAN_LIST_CHECKSUM_VALIDATION:false}
       checksumHeaderName: ${ACQ_BATCH_HPAN_LIST_CHECKSUM_HEADER:x-ms-meta-sha256}
@@ -124,7 +124,7 @@ rest-client:
       dateValidationHeaderName: ${ACQ_BATCH_HPAN_LIST_DATEVAL_HEADER:last-modified}
       dateValidationPattern: ${ACQ_BATCH_HPAN_LIST_DATE_VALIDATION_PATTERN:}
     salt:
-      url: /rtd/payment-instrument-manager/salt
+      url: /rtd/payment-instrument-manager/${ACQ_BATCH_HPAN_SALT_URL:v2/salt}
     adesas:
       url: /rtd/csv-transaction/ade/sas
     rtdsas:

--- a/ops_resources/example_config/application.yml
+++ b/ops_resources/example_config/application.yml
@@ -114,7 +114,7 @@ rest-client:
     api:
       key: ${HPAN_SERVICE_API_KEY:test}
     list:
-      url: /rtd/payment-instrument-manager/${ACQ_BATCH_HPAN_LIST_URL:hashed-pans}
+      url: /rtd/payment-instrument-manager/${ACQ_BATCH_HPAN_LIST_URL:v2/hashed-pans}
       attemptExtraction: ${ACQ_BATCH_HPAN_LIST_ATTEMPT_EXTRACT:true}
       checksumValidation: ${ACQ_BATCH_HPAN_LIST_CHECKSUM_VALIDATION:false}
       checksumHeaderName: ${ACQ_BATCH_HPAN_LIST_CHECKSUM_HEADER:x-ms-meta-sha256}
@@ -123,7 +123,7 @@ rest-client:
       dateValidationHeaderName: ${ACQ_BATCH_HPAN_LIST_DATEVAL_HEADER:last-modified}
       dateValidationPattern: ${ACQ_BATCH_HPAN_LIST_DATE_VALIDATION_PATTERN:}
     salt:
-      url: /rtd/payment-instrument-manager/salt
+      url: /rtd/payment-instrument-manager/${ACQ_BATCH_HPAN_SALT_URL:v2/salt}
     adesas:
       url: /rtd/csv-transaction/ade/sas
     rtdsas:

--- a/ops_resources/example_config/application_hbsql.yml
+++ b/ops_resources/example_config/application_hbsql.yml
@@ -92,7 +92,7 @@ rest-client:
     api:
       key: ${HPAN_SERVICE_API_KEY:test}
     list:
-      url: /rtd/payment-instrument-manager/${ACQ_BATCH_HPAN_LIST_URL:hashed-pans}
+      url: /rtd/payment-instrument-manager/${ACQ_BATCH_HPAN_LIST_URL:v2/hashed-pans}
       attemptExtraction: ${ACQ_BATCH_HPAN_LIST_ATTEMPT_EXTRACT:true}
       checksumValidation: ${ACQ_BATCH_HPAN_LIST_CHECKSUM_VALIDATION:false}
       checksumHeaderName: ${ACQ_BATCH_HPAN_LIST_CHECKSUM_HEADER:x-ms-meta-sha256}
@@ -101,7 +101,7 @@ rest-client:
       dateValidationHeaderName: ${ACQ_BATCH_HPAN_LIST_DATEVAL_HEADER:last-modified}
       dateValidationPattern: ${ACQ_BATCH_HPAN_LIST_DATE_VALIDATION_PATTERN:}
     salt:
-      url: /rtd/payment-instrument-manager/salt
+      url: /rtd/payment-instrument-manager/${ACQ_BATCH_HPAN_SALT_URL:v2/salt}
     adesas:
       url: /rtd/csv-transaction/ade/sas
     rtdsas:


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to replace the default endpoints of hashed-pans and salt with v2 version. The salt endpoint has been parametrized alike the hpans one.

#### List of Changes

<!--- Describe your changes in detail -->
- Update application files 

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The informally v1 endpoints are deprecated and must be replaced with the v2 ones. The url salt parametrization may be useful in the future to avoid dedicated release of the batch service to change the api version.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
