### PR TITLE
[RTD-485] fix typo in manageHpanOnSuccess property name

### DIFF
--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -78,7 +78,7 @@ batchConfiguration:
       linesToSkip: ${ACQ_BATCH_INPUT_LINES_TO_SKIP:0}
       deleteProcessedFiles: ${ACQ_BATCH_DELETE_LOCAL_FILE:false}
       deleteOutputFiles: ${ACQ_BATCH_DELETE_OUTPUT_FILE:ALWAYS}
-      manageHpanOnSuccess: ${ACH_BATCH_HPAN_ON_SUCCESS:DELETE}
+      manageHpanOnSuccess: ${ACQ_BATCH_HPAN_ON_SUCCESS:DELETE}
       transactionLogsPath: file:${ACQ_BATCH_TRX_LOGS_PATH:resources/errorLogs}
       inputFileChecksumEnabled: ${ACQ_BATCH_INPUT_FILE_CHECKSUM:true}
     transactionSenderRtd:


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to fix a typo in the `ACH_BATCH_HPAN_ON_SUCCESS` variable name.

#### List of Changes

<!--- Describe your changes in detail -->
- Fix typo

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
