### PR TITLE
[RTD-454] split env variables that pilot two different properties

### DIFF
--- a/api/batch/src/main/resources/config/panReaderStep.properties
+++ b/api/batch/src/main/resources/config/panReaderStep.properties
@@ -1,8 +1,8 @@
 batchConfiguration.TransactionFilterBatch.panList.hpanDirectoryPath=file:/${ACQ_BATCH_HPAN_INPUT_PATH:}/${ACQ_BATCH_INPUT_FILE_PATTERN:*.csv}
 batchConfiguration.TransactionFilterBatch.panList.secretKeyPath=file:/${ACQ_BATCH_INPUT_SECRET_KEYPATH:}
 batchConfiguration.TransactionFilterBatch.panList.passphrase=${ACQ_BATCH_INPUT_SECRET_PASSPHRASE:}
-batchConfiguration.TransactionFilterBatch.panList.partitionerSize=${ACQ_BATCH_INPUT_PARTITIONER_SIZE:10}
-batchConfiguration.TransactionFilterBatch.panList.chunkSize=${ACQ_BATCH_INPUT_CHUNK_SIZE:1000}
-batchConfiguration.TransactionFilterBatch.panList.skipLimit=${ACQ_BATCH_INPUT_SKIP_LIMIT:0}
+batchConfiguration.TransactionFilterBatch.panList.partitionerSize=${ACQ_BATCH_HPAN_PARTITIONER_SIZE:10}
+batchConfiguration.TransactionFilterBatch.panList.chunkSize=${ACQ_BATCH_HPAN_CHUNK_SIZE:1000}
+batchConfiguration.TransactionFilterBatch.panList.skipLimit=${ACQ_BATCH_HPAN_SKIP_LIMIT:0}
 batchConfiguration.TransactionFilterBatch.panList.applyDecrypt=${ACQ_BATCH_PAN_LIST_APPLY_DECRYPT:false}
 batchConfiguration.TransactionFilterBatch.panList.applyHashing=${ACQ_BATCH_PAN_LIST_APPLY_HASHING:false}

--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -61,9 +61,9 @@ batchConfiguration:
       hpanDirectoryPath: file:${ACQ_BATCH_HPAN_INPUT_PATH:resources/hpans}/${ACQ_BATCH_INPUT_FILE_PATTERN:*.csv}
       secretKeyPath: file:${ACQ_BATCH_INPUT_SECRET_KEYPATH:}
       passphrase: ${ACQ_BATCH_INPUT_SECRET_PASSPHRASE:}
-      partitionerSize: ${ACQ_BATCH_INPUT_PARTITIONER_SIZE:10}
-      chunkSize: ${ACQ_BATCH_INPUT_CHUNK_SIZE:1000}
-      skipLimit: ${ACQ_BATCH_INPUT_SKIP_LIMIT:0}
+      partitionerSize: ${ACQ_BATCH_HPAN_PARTITIONER_SIZE:10}
+      chunkSize: ${ACQ_BATCH_HPAN_CHUNK_SIZE:1000}
+      skipLimit: ${ACQ_BATCH_HPAN_SKIP_LIMIT:0}
       applyDecrypt: ${ACQ_BATCH_PAN_LIST_APPLY_DECRYPT:false}
       applyHashing: ${ACQ_BATCH_PAN_LIST_APPLY_HASHING:false}
     transactionFilter:
@@ -71,7 +71,7 @@ batchConfiguration:
       outputDirectoryPath: file:${ACQ_BATCH_OUTPUT_PATH:${ACQ_BATCH_TRX_INPUT_PATH:resources}/output}
       partitionerSize: ${ACQ_BATCH_INPUT_PARTITIONER_SIZE:10}
       chunkSize: ${ACQ_BATCH_INPUT_CHUNK_SIZE:1000}
-      skipLimit: ${ACQ_BATCH_INPUT_SKIP_LIMIT:1000}
+      skipLimit: ${ACQ_BATCH_INPUT_SKIP_LIMIT:0}
       timestampPattern: ${ACQ_BATCH_INPUT_TIMESTAMP_PATTERN:yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX}
       applyHashing: ${ACQ_BATCH_TRX_LIST_APPLY_HASHING:true}
       applyEncrypt: ${ACQ_BATCH_TRX_LIST_APPLY_ENCRYPT:true}

--- a/ops_resources/example_config/application.yml
+++ b/ops_resources/example_config/application.yml
@@ -60,9 +60,9 @@ batchConfiguration:
       hpanDirectoryPath: file:${ACQ_BATCH_HPAN_INPUT_PATH:resources/hpans}/${ACQ_BATCH_INPUT_FILE_PATTERN:*.csv}
       secretKeyPath: file:${ACQ_BATCH_INPUT_SECRET_KEYPATH:}
       passphrase: ${ACQ_BATCH_INPUT_SECRET_PASSPHRASE:}
-      partitionerSize: ${ACQ_BATCH_INPUT_PARTITIONER_SIZE:10}
-      chunkSize: ${ACQ_BATCH_INPUT_CHUNK_SIZE:1000}
-      skipLimit: ${ACQ_BATCH_INPUT_SKIP_LIMIT:0}
+      partitionerSize: ${ACQ_BATCH_HPAN_PARTITIONER_SIZE:10}
+      chunkSize: ${ACQ_BATCH_HPAN_CHUNK_SIZE:1000}
+      skipLimit: ${ACQ_BATCH_HPAN_SKIP_LIMIT:0}
       applyDecrypt: ${ACQ_BATCH_PAN_LIST_APPLY_DECRYPT:false}
       applyHashing: ${ACQ_BATCH_PAN_LIST_APPLY_HASHING:false}
     transactionFilter:
@@ -70,7 +70,7 @@ batchConfiguration:
       outputDirectoryPath: file:${ACQ_BATCH_OUTPUT_PATH:${ACQ_BATCH_TRX_INPUT_PATH:resources}/output}
       partitionerSize: ${ACQ_BATCH_INPUT_PARTITIONER_SIZE:10}
       chunkSize: ${ACQ_BATCH_INPUT_CHUNK_SIZE:1000}
-      skipLimit: ${ACQ_BATCH_INPUT_SKIP_LIMIT:1000}
+      skipLimit: ${ACQ_BATCH_INPUT_SKIP_LIMIT:0}
       timestampPattern: ${ACQ_BATCH_INPUT_TIMESTAMP_PATTERN:yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX}
       applyHashing: ${ACQ_BATCH_TRX_LIST_APPLY_HASHING:true}
       applyEncrypt: ${ACQ_BATCH_TRX_LIST_APPLY_ENCRYPT:true}

--- a/ops_resources/example_config/application_hbsql.yml
+++ b/ops_resources/example_config/application_hbsql.yml
@@ -38,9 +38,9 @@ batchConfiguration:
       hpanDirectoryPath: file:${ACQ_BATCH_HPAN_INPUT_PATH:resources/hpans}/${ACQ_BATCH_INPUT_FILE_PATTERN:*.csv}
       secretKeyPath: file:${ACQ_BATCH_INPUT_SECRET_KEYPATH:}
       passphrase: ${ACQ_BATCH_INPUT_SECRET_PASSPHRASE:}
-      partitionerSize: ${ACQ_BATCH_INPUT_PARTITIONER_SIZE:10}
-      chunkSize: ${ACQ_BATCH_INPUT_CHUNK_SIZE:1000}
-      skipLimit: ${ACQ_BATCH_INPUT_SKIP_LIMIT:0}
+      partitionerSize: ${ACQ_BATCH_HPAN_PARTITIONER_SIZE:10}
+      chunkSize: ${ACQ_BATCH_HPAN_CHUNK_SIZE:1000}
+      skipLimit: ${ACQ_BATCH_HPAN_SKIP_LIMIT:0}
       applyDecrypt: ${ACQ_BATCH_PAN_LIST_APPLY_DECRYPT:false}
       applyHashing: ${ACQ_BATCH_PAN_LIST_APPLY_HASHING:false}
     transactionFilter:
@@ -48,7 +48,7 @@ batchConfiguration:
       outputDirectoryPath: file:${ACQ_BATCH_OUTPUT_PATH:${ACQ_BATCH_TRX_INPUT_PATH:resources}/output}
       partitionerSize: ${ACQ_BATCH_INPUT_PARTITIONER_SIZE:10}
       chunkSize: ${ACQ_BATCH_INPUT_CHUNK_SIZE:1000}
-      skipLimit: ${ACQ_BATCH_INPUT_SKIP_LIMIT:1000}
+      skipLimit: ${ACQ_BATCH_INPUT_SKIP_LIMIT:0}
       timestampPattern: ${ACQ_BATCH_INPUT_TIMESTAMP_PATTERN:yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX}
       applyHashing: ${ACQ_BATCH_TRX_LIST_APPLY_HASHING:true}
       applyEncrypt: ${ACQ_BATCH_TRX_LIST_APPLY_ENCRYPT:true}


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to use distinct variables to pilot different property. Plus the `ACQ_BATCH_INPUT_SKIP_LIMIT` default value has been set to 0.

#### List of Changes

<!--- Describe your changes in detail -->
- Used distinct variables for different properties
- Set input skip limit to 0

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The overwrite of some environment variables may cause to alter the behaviour of different parts of the batch service. For that reason it is better to separate the variables that pilot different properties.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
