### PR TITLE
[RTD-652] set new pending directory to file management tasklet error …

### DIFF
--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/TransactionFilterBatch.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/TransactionFilterBatch.java
@@ -88,7 +88,7 @@ public class TransactionFilterBatch {
     private String successArchivePath;
     @Value("${batchConfiguration.TransactionFilterBatch.errorArchivePath}")
     private String errorArchivePath;
-    @Value("${batchConfiguration.TransactionFilterBatch.uploadArchivePath}")
+    @Value("${batchConfiguration.TransactionFilterBatch.pendingArchivePath}")
     private String pendingArchivePath;
     @Value("${batchConfiguration.TransactionFilterBatch.tablePrefix}")
     private String tablePrefix;

--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/TransactionFilterBatch.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/TransactionFilterBatch.java
@@ -88,6 +88,8 @@ public class TransactionFilterBatch {
     private String successArchivePath;
     @Value("${batchConfiguration.TransactionFilterBatch.errorArchivePath}")
     private String errorArchivePath;
+    @Value("${batchConfiguration.TransactionFilterBatch.transactionFilter.pendingDirectoryPath}")
+    private String pendingArchivePath;
     @Value("${batchConfiguration.TransactionFilterBatch.tablePrefix}")
     private String tablePrefix;
     @Value("${batchConfiguration.TransactionFilterBatch.hpanListRecovery.directoryPath}")
@@ -423,7 +425,7 @@ public class TransactionFilterBatch {
         FileManagementTasklet fileManagementTasklet = new FileManagementTasklet();
         fileManagementTasklet.setTransactionWriterService(transactionWriterService);
         fileManagementTasklet.setSuccessPath(successArchivePath);
-        fileManagementTasklet.setErrorPath(errorArchivePath);
+        fileManagementTasklet.setUploadPendingPath(pendingArchivePath);
         fileManagementTasklet.setHpanDirectory(panReaderStep.getHpanDirectoryPath());
         fileManagementTasklet.setOutputDirectory(transactionFilterStep.getOutputDirectoryPath());
         fileManagementTasklet.setDeleteProcessedFiles(deleteProcessedFiles);

--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/TransactionFilterBatch.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/TransactionFilterBatch.java
@@ -88,7 +88,7 @@ public class TransactionFilterBatch {
     private String successArchivePath;
     @Value("${batchConfiguration.TransactionFilterBatch.errorArchivePath}")
     private String errorArchivePath;
-    @Value("${batchConfiguration.TransactionFilterBatch.transactionFilter.pendingDirectoryPath}")
+    @Value("${batchConfiguration.TransactionFilterBatch.uploadArchivePath}")
     private String pendingArchivePath;
     @Value("${batchConfiguration.TransactionFilterBatch.tablePrefix}")
     private String tablePrefix;

--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/FileManagementTasklet.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/FileManagementTasklet.java
@@ -42,7 +42,6 @@ public class FileManagementTasklet implements Tasklet, InitializingBean {
     private String deleteOutputFiles;
     private String manageHpanOnSuccess;
     private String successPath;
-//    private String errorPath;
     private String uploadPendingPath;
     private String hpanDirectory;
     private String outputDirectory;
@@ -59,8 +58,6 @@ public class FileManagementTasklet implements Tasklet, InitializingBean {
         String assertionMessage = "directory must be set";
         Assert.notNull(resolver.getResources("file:" + successPath + "*.pgp"),
             assertionMessage);
-//        Assert.notNull(resolver.getResources("file:" + errorPath + "*.pgp"),
-//            assertionMessage);
         Assert.notNull(resolver.getResources("file:" + uploadPendingPath + "*.pgp"),
             assertionMessage);
         Assert.notNull(resolver.getResources(hpanDirectory),

--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/FileManagementTasklet.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/FileManagementTasklet.java
@@ -42,7 +42,8 @@ public class FileManagementTasklet implements Tasklet, InitializingBean {
     private String deleteOutputFiles;
     private String manageHpanOnSuccess;
     private String successPath;
-    private String errorPath;
+//    private String errorPath;
+    private String uploadPendingPath;
     private String hpanDirectory;
     private String outputDirectory;
     private String logsDirectory;
@@ -58,7 +59,9 @@ public class FileManagementTasklet implements Tasklet, InitializingBean {
         String assertionMessage = "directory must be set";
         Assert.notNull(resolver.getResources("file:" + successPath + "*.pgp"),
             assertionMessage);
-        Assert.notNull(resolver.getResources("file:" + errorPath + "*.pgp"),
+//        Assert.notNull(resolver.getResources("file:" + errorPath + "*.pgp"),
+//            assertionMessage);
+        Assert.notNull(resolver.getResources("file:" + uploadPendingPath + "*.pgp"),
             assertionMessage);
         Assert.notNull(resolver.getResources(hpanDirectory),
             assertionMessage);
@@ -194,7 +197,7 @@ public class FileManagementTasklet implements Tasklet, InitializingBean {
 
     @SneakyThrows
     private void archiveFile(String file, String path, boolean isCompleted) {
-        String archivalPath = isCompleted ? successPath : errorPath;
+        String archivalPath = isCompleted ? successPath : uploadPendingPath;
         file = makePathSystemIndependent(file);
         String[] filename = file.split("/");
         DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS");

--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/FileManagementTasklet.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/FileManagementTasklet.java
@@ -194,14 +194,28 @@ public class FileManagementTasklet implements Tasklet, InitializingBean {
 
     @SneakyThrows
     private void archiveFile(String file, String path, boolean isCompleted) {
-        String archivalPath = isCompleted ? successPath : uploadPendingPath;
-        file = makePathSystemIndependent(file);
-        String[] filename = file.split("/");
-        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS");
-        archivalPath = resolver.getResources(archivalPath)[0].getFile().getAbsolutePath();
-        File destFile = FileUtils.getFile(archivalPath + "/" + SecureRandom.getInstanceStrong().nextLong() +
-                "_" + OffsetDateTime.now().format(fmt) + "_" + filename[filename.length - 1]);
-        FileUtils.moveFile(FileUtils.getFile(path), destFile);
+        File destinationFile = getDestionationFileByStatus(file, isCompleted);
+        FileUtils.moveFile(FileUtils.getFile(path), destinationFile);
+    }
+
+    @SneakyThrows
+    private File getDestionationFileByStatus(String sourceFilePath, boolean isCompleted) {
+
+        sourceFilePath = makePathSystemIndependent(sourceFilePath);
+        String[] pathSplitted = sourceFilePath.split("/");
+        String filename = pathSplitted[pathSplitted.length - 1];
+        String destinationPath;
+        if (isCompleted) {
+            String archivalPath = resolver.getResources(successPath)[0].getFile().getAbsolutePath();
+            DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS");
+            destinationPath = archivalPath + File.separator + SecureRandom.getInstanceStrong().nextLong() +
+                "_" + OffsetDateTime.now().format(fmt) + "_" + filename;
+        } else {
+            String archivalPath = resolver.getResources(uploadPendingPath)[0].getFile().getAbsolutePath();
+            destinationPath = archivalPath + File.separator + filename;
+        }
+
+        return FileUtils.getFile(destinationPath);
     }
 
     @SneakyThrows

--- a/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/FileManagementTaskletTest.java
+++ b/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/FileManagementTaskletTest.java
@@ -55,7 +55,7 @@ public class FileManagementTaskletTest {
             PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
 
             FileManagementTasklet archivalTasklet = new FileManagementTasklet();
-            archivalTasklet.setErrorPath("classpath:/test-encrypt/**/test1/error");
+            archivalTasklet.setUploadPendingPath("classpath:/test-encrypt/**/test1/error");
             archivalTasklet.setSuccessPath("classpath:/test-encrypt/**/test1/success");
             archivalTasklet.setOutputDirectory("classpath:/test-encrypt/**/test1/output");
             archivalTasklet.setHpanDirectory("file:/"+resolver.getResources(
@@ -171,7 +171,7 @@ public class FileManagementTaskletTest {
             PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
 
             FileManagementTasklet archivalTasklet = new FileManagementTasklet();
-            archivalTasklet.setErrorPath("classpath:/test-encrypt/**/test1/error");
+            archivalTasklet.setUploadPendingPath("classpath:/test-encrypt/**/test1/error");
             archivalTasklet.setSuccessPath("classpath:/test-encrypt/**/test1/success");
             archivalTasklet.setOutputDirectory("classpath:/test-encrypt/**/test1/output");
             archivalTasklet.setHpanDirectory("file:/"+resolver.getResources(
@@ -286,7 +286,7 @@ public class FileManagementTaskletTest {
             tempFolder.newFile("test2/output/error-trx-output-file.csv");
 
             FileManagementTasklet archivalTasklet = new FileManagementTasklet();
-            archivalTasklet.setErrorPath("classpath:/test-encrypt/**/error");
+            archivalTasklet.setUploadPendingPath("classpath:/test-encrypt/**/error");
             archivalTasklet.setSuccessPath("classpath:/test-encrypt/**/success");
             archivalTasklet.setOutputDirectory("classpath:/test-encrypt/**/output");
             archivalTasklet.setHpanDirectory("classpath:/test-encrypt/**/hpan");
@@ -396,7 +396,7 @@ public class FileManagementTaskletTest {
 
             PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
             FileManagementTasklet archivalTasklet = new FileManagementTasklet();
-            archivalTasklet.setErrorPath("classpath:/test-encrypt/**/test3/error");
+            archivalTasklet.setUploadPendingPath("classpath:/test-encrypt/**/test3/error");
             archivalTasklet.setSuccessPath("classpath:/test-encrypt/**/test3/success");
             archivalTasklet.setOutputDirectory("classpath:/test-encrypt/**/test3/output");
             archivalTasklet.setHpanDirectory("file:/"+resolver.getResources(
@@ -506,7 +506,7 @@ public class FileManagementTaskletTest {
 
             PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
             FileManagementTasklet archivalTasklet = new FileManagementTasklet();
-            archivalTasklet.setErrorPath("classpath:/test-encrypt/**/test4/error");
+            archivalTasklet.setUploadPendingPath("classpath:/test-encrypt/**/test4/error");
             archivalTasklet.setSuccessPath("classpath:/test-encrypt/**/test4/success");
             archivalTasklet.setOutputDirectory("classpath:/test-encrypt/**/test4/output");
             archivalTasklet.setHpanDirectory("file:/"+resolver.getResources(


### PR DESCRIPTION
…case

#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to move the file that failed the upload in the folder `output/pending` instead of `input/error`. The naming convention is differentiated between the success path and the pending path

#### List of Changes

<!--- Describe your changes in detail -->
- Changed the file management tasklet

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The batch service is going to implement the re-send of the files that failed the upload. To do so it will get files from the new pending directory. Therefore the file management tasklet must adapt to move the files in that directory.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
