### PR TITLE
fix: [RTD-733] fix output archived after batch service

### DIFF
--- a/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/FileManagementTaskletTest.java
+++ b/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/FileManagementTaskletTest.java
@@ -29,6 +29,7 @@ public class FileManagementTaskletTest {
     File errorFile;
     File hpanFile;
     File errorHpanFile;
+    File outputFileCsv;
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder(
@@ -53,6 +54,7 @@ public class FileManagementTaskletTest {
             tempFolder.newFile("test1/output/error-trx-output-file.pgp");
             tempFolder.newFile("test1/output/success-trx-output-file.pgp");
             tempFolder.newFile("test1/output/error-trx-output-file.csv");
+            outputFileCsv = tempFolder.newFile("test1/output/success-trx-output-file.csv");
 
             PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
 
@@ -119,8 +121,13 @@ public class FileManagementTaskletTest {
 
             StepExecution stepExecution5 = MetaDataInstanceFactory.createStepExecution("E", 1L);
             stepExecution5.setStatus(BatchStatus.COMPLETED);
-            stepExecution5.getExecutionContext().put("fileName",successFile.getAbsolutePath());
+            stepExecution5.getExecutionContext().put("fileName", successFile.getAbsolutePath());
             stepExecutions.add(stepExecution5);
+
+            StepExecution stepExecution6 = MetaDataInstanceFactory.createStepExecution("F", 1L);
+            stepExecution6.setStatus(BatchStatus.COMPLETED);
+            stepExecution6.getExecutionContext().put("fileName",outputFileCsv.getAbsolutePath());
+            stepExecutions.add(stepExecution6);
 
             execution = MetaDataInstanceFactory.createStepExecution();
             stepContext = new StepContext(execution);
@@ -139,7 +146,7 @@ public class FileManagementTaskletTest {
                             resolver.getResources("classpath:/test-encrypt/**/test1/output")[0].getFile(),
                             new String[]{"pgp"},false).size());
 
-            Assert.assertEquals(1,
+            Assert.assertEquals(2,
                     FileUtils.listFiles(
                             resolver.getResources("classpath:/test-encrypt/**/test1/output")[0].getFile(),
                             new String[]{"csv"},false).size());


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to fix a bug with the file management step. The output files get archived in success / error directory instead of getting piloted by the appropriate env var `ACQ_BATCH_DELETE_OUTPUT_FILE`.

#### List of Changes

<!--- Describe your changes in detail -->
- Changed `FileManagementTasklet`
- Updated unit test to verify the output directory

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The last feature pointed out a bad file management in the dedicated task. It's been introduced a flag to manage the output files in an appropriate way. 
As consequence the mechanism which moved the `.pgp` files into success directory is no longer valid and those files are handled by the same env var mentioned before.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
