### PR TITLE
fix: [RTD-674] change naming convention and parametrize timeout

### DIFF
--- a/acceptance_tests/ingestion_big_files/script_ingestion.bash
+++ b/acceptance_tests/ingestion_big_files/script_ingestion.bash
@@ -17,7 +17,7 @@ TIMEOUT_IN_MINUTES="${2:-250}"
 
 sh ../common/setup.sh
 
-N_AGGREGATES=50
+N_AGGREGATES=6000000
 
 ### file generation
 cd cstar-cli || exit

--- a/acceptance_tests/ingestion_big_files/script_ingestion.bash
+++ b/acceptance_tests/ingestion_big_files/script_ingestion.bash
@@ -1,12 +1,19 @@
 #!/bin/bash
 
+# This script tests the ingestion of a file of big dimension.
+# By default it will generate a single chunk of 6M rows but it is
+# customizable to generate more chunks by tuning N_AGGREGATES and
+# ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD values
+
 if [ $# -ne 1 ] ; then
     echo "Illegal number of parameters (1 mandatory, was $#)" >&1
-    echo "usage: bash script_splitting.bash env" >&1
+    echo "usage: bash script_splitting.bash env [timeout_in_minutes]" >&1
     exit 2
 fi
 
 ENV=$1
+# timeout default 250m (aggregates-ingestor takes around 3h to complete)
+TIMEOUT_IN_MINUTES="${2:-250}"
 
 sh ../common/setup.sh
 
@@ -41,39 +48,39 @@ java -jar ../common/rtd-ms-transaction-filter.jar
 # set threshold if not present
 if [ -z "$ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD" ]
 then
-      ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD=1000000
+    ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD=1000000
 fi
 
 # find chunks number
 if [ $N_AGGREGATES -lt $ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD ]
 then
-	N_CHUNKS=1
+	  N_CHUNKS=1
 else
-	N_CHUNKS=$(( ( N_AGGREGATES / ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD ) + ( N_AGGREGATES % ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD > 0 ) ))
+	  N_CHUNKS=$(( ( N_AGGREGATES / ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD ) + ( N_AGGREGATES % ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD > 0 ) ))
 fi
 
 OUTPUT_WITHOUT_EXTENSION="ADE.$(echo "$FILENAME" | cut -d'.' -f2-6)"
 # check output files generated
 for (( i=1; i<=N_CHUNKS; i++ ))
 do
-	# there is a limitation to 9 chunks!!!!
-	FILENAME_CHUNKED="$OUTPUT_WITHOUT_EXTENSION.0$i.csv"
-	if test -f "$ACQ_BATCH_OUTPUT_PATH/$FILENAME_CHUNKED"; then
-    	echo "$FILENAME_CHUNKED exists: [SUCCESS]"
-	else
-    	echo "$FILENAME_CHUNKED does not exist: [FAILED]"
-    	exit 2
-	fi
+    # there is a limitation to 9 chunks!!!!
+    FILENAME_CHUNKED="$OUTPUT_WITHOUT_EXTENSION.0$i.csv"
+    if test -f "$ACQ_BATCH_OUTPUT_PATH/$FILENAME_CHUNKED"; then
+        echo "$FILENAME_CHUNKED exists: [SUCCESS]"
+    else
+        echo "$FILENAME_CHUNKED does not exist: [FAILED]"
+        exit 2
+    fi
 done
 
 # 2. check application log to find evidence of successful files upload
 N_UPLOADS=$(grep -c "uploaded with success (status was: 201)" < workdir/logs/application.log)
 if [ $N_CHUNKS -ne "$N_UPLOADS" ]
 then
-	echo "Upload test not passed, $N_CHUNKS chunks vs $N_UPLOADS uploaded: [FAILED]"
-	exit 2
+    echo "Upload test not passed, $N_CHUNKS chunks vs $N_UPLOADS uploaded: [FAILED]"
+    exit 2
 else
-	echo "Files uploaded with success: [SUCCESS]"
+	  echo "Files uploaded with success: [SUCCESS]"
 fi
 
 # cli atm do not support chunk generation, it can be arranged like this:
@@ -83,8 +90,8 @@ if [ -z "$LOCAL_OUTPUT_DIFF" ]
 then
   	echo "Diff local output with expected: [SUCCESS]"
 else
-	echo "Diff local output with expected: [FAILED]"
-	exit 2
+    echo "Diff local output with expected: [FAILED]"
+    exit 2
 fi
 
 # 3. check files on ade container
@@ -92,47 +99,44 @@ fi
 # timeout should be parametrized on the dimension of the input file
 SLEEP_INTERVAL_IN_SECONDS=60
 ADE_FILENAME_WITHOUT_EXTENSION=AGGADE.$(echo "$OUTPUT_WITHOUT_EXTENSION"  | cut -d'.' -f2,4-6)
-for i in {1..10}
+for (( i=0 ; i <= TIMEOUT_IN_MINUTES; i++))
 do
-	echo "Waiting $SLEEP_INTERVAL_IN_SECONDS seconds..."
-	sleep $SLEEP_INTERVAL_IN_SECONDS
+    echo "Waiting $SLEEP_INTERVAL_IN_SECONDS seconds..."
+    sleep $SLEEP_INTERVAL_IN_SECONDS
 
-	# accedo sftp per recuperare i file
-	# verifico presenza dei file (controllare anche contenuto?)
-	ALL_FILES_FOUND=true
-	for (( j=1; j<=N_CHUNKS; j++ ))
-	do
-		# there is a limitation to 9 chunks!!!!
-		ADE_FILENAME_CHUNKED="$ADE_FILENAME_WITHOUT_EXTENSION.0${j}000.gz"
-		RESPONSE=$(curl \
-	            --silent --output "$ADE_FILENAME_CHUNKED" \
-	            --write-out '%{http_code}' \
-	            --cert ../certs/certificate.pem \
-	            --key ../certs/private.key \
-	            --header "Ocp-Apim-Subscription-Key: $HPAN_SERVICE_API_KEY" \
-	            "$HPAN_SERVICE_URL/rtd/sftp-retrieve/$ADE_FILENAME_CHUNKED")
+    ALL_FILES_FOUND=true
+    for (( j=0; j<3; j++ ))
+    do
+        ADE_FILENAME_CHUNKED="$ADE_FILENAME_WITHOUT_EXTENSION.0100${j}.gz"
+        RESPONSE=$(curl \
+                  --silent --output "$ADE_FILENAME_CHUNKED" \
+                  --write-out '%{http_code}' \
+                  --cert ../certs/certificate.pem \
+                  --key ../certs/private.key \
+                  --header "Ocp-Apim-Subscription-Key: $HPAN_SERVICE_API_KEY" \
+                  "$HPAN_SERVICE_URL/rtd/sftp-retrieve/$ADE_FILENAME_CHUNKED")
 
-		if [ "$RESPONSE" -eq 404 ]
-		then
-			echo "file $ADE_FILENAME_CHUNKED not found"
-			rm "$ADE_FILENAME_CHUNKED"
-			ALL_FILES_FOUND=false
-			echo "Retrying..."
-			break
-		fi
-	done
+        if [ "$RESPONSE" -eq 404 ]
+        then
+            echo "file $ADE_FILENAME_CHUNKED not found"
+            rm "$ADE_FILENAME_CHUNKED"
+            ALL_FILES_FOUND=false
+            echo "Retrying..."
+            break
+        fi
+    done
 
-	if [ $ALL_FILES_FOUND == true ]
-	then
-		echo "All Ade files found: [SUCCESS]"
-		break
-	fi
+    if [ $ALL_FILES_FOUND == true ]
+    then
+        echo "All Ade files found: [SUCCESS]"
+        break
+    fi
 done
 
 if [ $ALL_FILES_FOUND == false ]
 then
-	echo "Ade files not found: [FAILED]"
-	exit 2
+    echo "Ade files not found: [FAILED]"
+	  exit 2
 fi
 
 exit 0

--- a/acceptance_tests/ingestion_big_files/script_ingestion.bash
+++ b/acceptance_tests/ingestion_big_files/script_ingestion.bash
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 # This script tests the ingestion of a file of big dimension.
-# By default it will generate a single chunk of 6M rows but it is
-# customizable by tuning N_AGGREGATES value.
-# Keep in mind N_AGGREGATES must not be bigger than the ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD.
+# By default it will generate a single chunk of 6M rows and expect the decrypter will generate
+# 3 output chunks.
 # The script does not support the generation of more than one chunk!
 
 if [ $# -ne 1 ] ; then
@@ -18,7 +17,7 @@ TIMEOUT_IN_MINUTES="${2:-250}"
 
 sh ../common/setup.sh
 
-N_AGGREGATES=6000000
+N_AGGREGATES=50
 
 ### file generation
 cd cstar-cli || exit

--- a/acceptance_tests/ingestion_big_files/script_ingestion.bash
+++ b/acceptance_tests/ingestion_big_files/script_ingestion.bash
@@ -2,8 +2,9 @@
 
 # This script tests the ingestion of a file of big dimension.
 # By default it will generate a single chunk of 6M rows but it is
-# customizable to generate more chunks by tuning N_AGGREGATES and
-# ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD values
+# customizable by tuning N_AGGREGATES value.
+# Keep in mind N_AGGREGATES must not be bigger than the ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD.
+# The script does not support the generation of more than one chunk!
 
 if [ $# -ne 1 ] ; then
     echo "Illegal number of parameters (1 mandatory, was $#)" >&1
@@ -46,45 +47,45 @@ java -jar ../common/rtd-ms-transaction-filter.jar
 #### ASSERTIONS
 # 1. check local output files generated
 # set threshold if not present
-if [ -z "$ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD" ]
-then
-    ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD=1000000
-fi
+#if [ -z "$ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD" ]
+#then
+#    ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD=1000000
+#fi
 
 # find chunks number
-if [ $N_AGGREGATES -lt $ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD ]
-then
-	  N_CHUNKS=1
-else
-	  N_CHUNKS=$(( ( N_AGGREGATES / ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD ) + ( N_AGGREGATES % ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD > 0 ) ))
-fi
+#if [ $N_AGGREGATES -lt $ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD ]
+#then
+#	  N_CHUNKS=1
+#else
+#	  N_CHUNKS=$(( ( N_AGGREGATES / ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD ) + ( N_AGGREGATES % ACQ_BATCH_WRITER_ADE_SPLIT_THRESHOLD > 0 ) ))
+#fi
 
 OUTPUT_WITHOUT_EXTENSION="ADE.$(echo "$FILENAME" | cut -d'.' -f2-6)"
 # check output files generated
-for (( i=1; i<=N_CHUNKS; i++ ))
-do
-    # there is a limitation to 9 chunks!!!!
-    FILENAME_CHUNKED="$OUTPUT_WITHOUT_EXTENSION.0$i.csv"
-    if test -f "$ACQ_BATCH_OUTPUT_PATH/$FILENAME_CHUNKED"; then
-        echo "$FILENAME_CHUNKED exists: [SUCCESS]"
-    else
-        echo "$FILENAME_CHUNKED does not exist: [FAILED]"
-        exit 2
-    fi
-done
+#for (( i=1; i<=N_CHUNKS; i++ ))
+#do
+
+FILENAME_CHUNKED="$OUTPUT_WITHOUT_EXTENSION.01.csv"
+if test -f "$ACQ_BATCH_OUTPUT_PATH/$FILENAME_CHUNKED"; then
+    echo "$FILENAME_CHUNKED exists: [SUCCESS]"
+else
+    echo "$FILENAME_CHUNKED does not exist: [FAILED]"
+    exit 2
+fi
+#done
 
 # 2. check application log to find evidence of successful files upload
 N_UPLOADS=$(grep -c "uploaded with success (status was: 201)" < workdir/logs/application.log)
-if [ $N_CHUNKS -ne "$N_UPLOADS" ]
+if [ "$N_UPLOADS" -ne 1 ]
 then
-    echo "Upload test not passed, $N_CHUNKS chunks vs $N_UPLOADS uploaded: [FAILED]"
+    echo "Upload test not passed, $N_UPLOADS files uploaded: [FAILED]"
     exit 2
 else
-	  echo "Files uploaded with success: [SUCCESS]"
+	  echo "File uploaded with success: [SUCCESS]"
 fi
 
 # cli atm do not support chunk generation, it can be arranged like this:
-LOCAL_OUTPUT_DIFF=$(diff <(cat cstar-cli/generated/ADE.*expected | sort) <(cat workdir/output/ADE.*.csv | sort | tail -n +$N_CHUNKS))
+LOCAL_OUTPUT_DIFF=$(diff <(cat cstar-cli/generated/ADE.*expected | sort) <(cat workdir/output/ADE.*.csv | sort | tail -n +1))
 
 if [ -z "$LOCAL_OUTPUT_DIFF" ]
 then


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to fix the ingestion script with the correct naming convention and to parametrize che test timeout. 

#### List of Changes

<!--- Describe your changes in detail -->
- Fix naming convention
- Parametrize test timeout

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The pipelines take around 180-190 minutes to complete, then the new default value has been set to 250 minutes. The naming convention has been adapted to the decrypter one.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
