### PR TITLE
fix: [RTD-849] mitigation on sender ade ack file already exists exception

### DIFF
--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/SenderAdeAckFilesRecoveryTasklet.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/SenderAdeAckFilesRecoveryTasklet.java
@@ -74,7 +74,7 @@ public class SenderAdeAckFilesRecoveryTasklet implements Tasklet, InitializingBe
       try {
         FileUtils.moveFile(sourceFile, outputFile);
       } catch(FileExistsException exception) {
-        log.debug("File {} already exists and will not be downloaded.", outputFile.getName());
+        log.debug("File {} already exists and will not be overwritten.", outputFile.getName());
       }
     }
   }

--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/SenderAdeAckFilesRecoveryTasklet.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/SenderAdeAckFilesRecoveryTasklet.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileExistsException;
 import org.apache.commons.io.FileUtils;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
@@ -70,7 +71,11 @@ public class SenderAdeAckFilesRecoveryTasklet implements Tasklet, InitializingBe
   private void saveFilesToOutputDirectory(List<File> senderAdeAckFiles) throws IOException {
     for (File sourceFile : senderAdeAckFiles) {
       File outputFile = createOutputFile(sourceFile.getName());
-      FileUtils.moveFile(sourceFile, outputFile);
+      try {
+        FileUtils.moveFile(sourceFile, outputFile);
+      } catch(FileExistsException exception) {
+        log.debug("File {} already exists and will not be downloaded.", outputFile.getName());
+      }
     }
   }
 

--- a/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/SenderAdeAckFilesRecoveryTaskletTest.java
+++ b/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/tasklet/SenderAdeAckFilesRecoveryTaskletTest.java
@@ -1,6 +1,7 @@
 package it.gov.pagopa.rtd.transaction_filter.batch.step.tasklet;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 
@@ -167,6 +168,19 @@ class SenderAdeAckFilesRecoveryTaskletTest {
 
     assertThatThrownBy(() -> tasklet.afterPropertiesSet())
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @SneakyThrows
+  @Test
+  void givenAFileAlreadySavedWhenGetAdeAckFilesThenDoNotThrowException() {
+    Files.createFile(temporaryOutputPath.resolve("senderAdeAck1.txt"));
+    BDDMockito.doReturn(Collections.singletonList(defaultResponse.get(0))).when(restClient)
+        .getSenderAdeAckFiles();
+
+    // assert that FileExistsException is not thrown
+    StepContribution stepContribution = new StepContribution(execution);
+    assertThatCode(() -> tasklet.execute(stepContribution, chunkContext))
+        .doesNotThrowAnyException();
   }
 
   SenderAdeAckFilesRecoveryTasklet createDefaultTasklet() {


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add the error handling in case a ade ack file has already been downloaded by the sender.

#### List of Changes

<!--- Describe your changes in detail -->
- added try-catch for specific exception
- added test case

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When the batch service tries to download an ade-ack already downloaded in a previous run, then a FileExistsException is thrown. In order to handle the error case (and exception log), a try-catch has been added.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore change (non-breaking change which doesn't provide a direct value to users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
