### PR TITLE
fix: [RTD-845] fix sender-ade-ack property path level

### DIFF
--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -139,13 +139,6 @@ rest-client:
       url: /rtd/csv-transaction/publickey
     abi-to-fiscalcode-map:
       url: /rtd/abi-to-fiscalcode/conversion-map
-    sender-ade-ack:
-      list:
-        url: /rtd/file-register/sender-ade-ack
-      download-file:
-        url: /ade/{id}
-      received:
-        url: /rtd/file-register/ack-received/{id}
     mtls:
       enabled: ${HPAN_SERVICE_MTLS_ENABLED:true}
     key-store:
@@ -161,6 +154,13 @@ rest-client:
     header:
       blobType: BlockBlob
       version: "2021-08-06"
+  sender-ade-ack:
+    list:
+      url: /rtd/file-register/sender-ade-ack
+    download-file:
+      url: /ade/{id}
+    received:
+      url: /rtd/file-register/ack-received/{id}
 
 feign:
   client:

--- a/ops_resources/example_config/application.yml
+++ b/ops_resources/example_config/application.yml
@@ -138,13 +138,6 @@ rest-client:
       url: /rtd/csv-transaction/publickey
     abi-to-fiscalcode-map:
       url: /rtd/abi-to-fiscalcode/conversion-map
-    sender-ade-ack:
-      list:
-        url: /rtd/file-register/sender-ade-ack
-      download-file:
-        url: /ade/{id}
-      received:
-        url: /rtd/file-register/ack-received/{id}
     mtls:
       enabled: ${HPAN_SERVICE_MTLS_ENABLED:true}
     key-store:
@@ -160,6 +153,13 @@ rest-client:
     header:
       blobType: BlockBlob
       version: "2021-08-06"
+  sender-ade-ack:
+    list:
+      url: /rtd/file-register/sender-ade-ack
+    download-file:
+      url: /ade/{id}
+    received:
+      url: /rtd/file-register/ack-received/{id}
 
 feign:
   client:

--- a/ops_resources/example_config/application_hbsql.yml
+++ b/ops_resources/example_config/application_hbsql.yml
@@ -116,13 +116,6 @@ rest-client:
       url: /rtd/csv-transaction/publickey
     abi-to-fiscalcode-map:
       url: /rtd/abi-to-fiscalcode/conversion-map
-    sender-ade-ack:
-      list:
-        url: /rtd/file-register/sender-ade-ack
-      download-file:
-        url: /ade/{id}
-      received:
-        url: /rtd/file-register/ack-received/{id}
     mtls:
       enabled: ${HPAN_SERVICE_MTLS_ENABLED:true}
     key-store:
@@ -138,6 +131,13 @@ rest-client:
     header:
       blobType: BlockBlob
       version: "2021-08-06"
+  sender-ade-ack:
+    list:
+      url: /rtd/file-register/sender-ade-ack
+    download-file:
+      url: /ade/{id}
+    received:
+      url: /rtd/file-register/ack-received/{id}
 
 feign:
   client:


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to align the sender-ade-ack property definition inside the application.yml with the one defined in the submodule integration.rest. (`rest-client.sender-ade-ack` instead of `rest-client.hpan.sender-ade-ack`)

#### List of Changes

<!--- Describe your changes in detail -->
- changed property definition in application.yml

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The property read is different from the one defined in the application.yml.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore change (non-breaking change which doesn't provide a direct value to users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
