### PR TITLE
feat: [RTD-954] add min and max validation on amount input field

### DIFF
--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/model/InboundTransaction.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/model/InboundTransaction.java
@@ -1,6 +1,7 @@
 package it.gov.pagopa.rtd.transaction_filter.batch.model;
 
 import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
@@ -88,6 +89,7 @@ InboundTransaction {
      * max value: 999.999.999,99€
      */
     @NotNull
+    @Min(value = 0)
     @Max(value = 99999999999L)
     Long amount;
 

--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/model/InboundTransaction.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/model/InboundTransaction.java
@@ -1,5 +1,6 @@
 package it.gov.pagopa.rtd.transaction_filter.batch.model;
 
+import javax.validation.constraints.Max;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
@@ -84,8 +85,10 @@ InboundTransaction {
 
     /**
      * Transaction amount
+     * max value: 999.999.999,99€
      */
     @NotNull
+    @Max(value = 99999999999L)
     Long amount;
 
     /**

--- a/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/processor/InboundTransactionItemProcessorValidatorTest.java
+++ b/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/processor/InboundTransactionItemProcessorValidatorTest.java
@@ -229,7 +229,7 @@ public class InboundTransactionItemProcessorValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(longs = {1000, 200000, Integer.MAX_VALUE + 1L, 3000000000L, 99999999999L})
+    @ValueSource(longs = {0, 1000, 200000, Integer.MAX_VALUE + 1L, 3000000000L, 99999999999L})
     void processTransactionWithValidAmount(Long amount) {
         BDDMockito.doReturn(true).when(storeServiceMock).hasHpan(FAKE_ENROLLED_PAN);
         BDDMockito.doReturn(FAKE_SALT).when(storeServiceMock).getSalt();
@@ -242,7 +242,7 @@ public class InboundTransactionItemProcessorValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(longs = {100000000000L})
+    @ValueSource(longs = {-100L, 100000000000L})
     void processTransactionWithInvalidAmount(Long amount) {
         BDDMockito.doReturn(true).when(storeServiceMock).hasHpan(FAKE_ENROLLED_PAN);
         BDDMockito.doReturn(FAKE_SALT).when(storeServiceMock).getSalt();

--- a/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/processor/InboundTransactionItemProcessorValidatorTest.java
+++ b/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/step/processor/InboundTransactionItemProcessorValidatorTest.java
@@ -229,7 +229,7 @@ public class InboundTransactionItemProcessorValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(longs = {1000, 200000})
+    @ValueSource(longs = {1000, 200000, Integer.MAX_VALUE + 1L, 3000000000L, 99999999999L})
     void processTransactionWithValidAmount(Long amount) {
         BDDMockito.doReturn(true).when(storeServiceMock).hasHpan(FAKE_ENROLLED_PAN);
         BDDMockito.doReturn(FAKE_SALT).when(storeServiceMock).getSalt();
@@ -239,6 +239,17 @@ public class InboundTransactionItemProcessorValidatorTest {
         InboundTransaction outbound = processor.process(transaction);
         Assertions.assertNotNull(outbound);
         Assertions.assertEquals(amount, outbound.getAmount());
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {100000000000L})
+    void processTransactionWithInvalidAmount(Long amount) {
+        BDDMockito.doReturn(true).when(storeServiceMock).hasHpan(FAKE_ENROLLED_PAN);
+        BDDMockito.doReturn(FAKE_SALT).when(storeServiceMock).getSalt();
+        InboundTransaction transaction = fakeInboundTransaction();
+        transaction.setAmount(amount);
+        InboundTransactionItemProcessor processor = new InboundTransactionItemProcessor(storeServiceMock, false);
+        Assertions.assertThrows(ConstraintViolationException.class, () -> processor.process(transaction));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add a validation on the field `amount` of the input transaction file. Min value admitted is 0 and max value is 10^11 -1 (99.999.999.999).

#### List of Changes

<!--- Describe your changes in detail -->
- add the field validation and related unit tests

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The amount field needs to have a maximum and minimum value admitted.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Chore change (non-breaking change which doesn't provide a direct value to users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
