### PR TITLE
chore: [RTD-1121] Test multiple senders in file report

### DIFF
--- a/acceptance_tests/file_report/file_report_more_sender_codes.bash
+++ b/acceptance_tests/file_report/file_report_more_sender_codes.bash
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+if [ $# -lt 1 ] ; then
+    echo "Illegal number of parameters (1 mandatory, was $#)" >&1
+    echo "usage: bash script_splitting.bash env [timeout_in_minutes] [sender_code_1] [sender_code_2]" >&1
+    exit 2
+fi
+
+if [ "$1" != "uat" ] &&  [ "$1" != "dev" ]
+then
+    echo "only dev and uat available for this test!"
+    exit 2
+fi
+
+
+ENV=$1
+# timeout default 5minutes
+TIMEOUT_IN_MINUTES="${2:-5}"
+
+SENDER_CODE1="${3-12345}"
+SENDER_CODE2="${4-54321}"
+
+sh ../common/setup.sh
+
+N_AGGREGATES=8
+
+REPORT_DIR=workdir/reports
+
+echo "Make sure to have $SENDER_CODE1 and $SENDER_CODE2 associated with your API key"
+echo "Make sure to have empty cstar-cli/generated folder"
+
+generate_input_file() {
+    cd cstar-cli || exit
+    echo "Generating input file..."
+    poetry run cst sender aggregates --sender $SENDER_CODE1 --action trx_and_aggr --aggr-qty $N_AGGREGATES --avg-trx 3
+    poetry run cst sender aggregates --sender $SENDER_CODE2 --action trx_and_aggr --aggr-qty $N_AGGREGATES --avg-trx 3
+    cd ..
+    FILENAME=$(ls -1 cstar-cli/generated/*.csv | xargs -I {} basename {})
+    echo "Generated:"
+    echo "$FILENAME"
+    cp cstar-cli/generated/*.csv ./workdir/input/
+}
+run_batch_service() {
+    java -jar ../common/rtd-ms-transaction-filter.jar
+}
+get_file_sent_occurrence_in_report() {
+    OUTPUT_FILENAME=$(ls workdir/output | grep -E "ADE.*.pgp")
+    FILE_REPORT_NAME=$(ls -v "$REPORT_DIR" | tail -n 1)
+    FILES_SENT_OCCURRENCES_IN_REPORT=$(grep -c "$OUTPUT_FILENAME" < "$REPORT_DIR"/"$FILE_REPORT_NAME")
+}
+check_two_files_sent() {
+  # check if file has been uploaded
+  N_UPLOADS=$(grep -c "uploaded with success (status was: 201)" < workdir/logs/application.log)
+  if [ "$N_UPLOADS" -ne 2 ]
+  then
+    echo "Upload test not passed, $N_UPLOADS files uploaded: [FAILED]"
+    exit 2
+  else
+    echo "Files uploaded with success: [SUCCESS]"
+  fi
+}
+
+### file generation
+generate_input_file
+
+### batch service configuration
+# shellcheck source=../common/setenv_env.sh
+source ../common/setenv_"$ENV".sh
+source setenv.sh
+
+export ACQ_BATCH_SCHEDULED=false
+export ACQ_BATCH_FILE_REPORT_PATH="$REPORT_DIR"
+
+echo "Executing batch service..."
+### batch service run
+run_batch_service
+run_batch_service
+#### ASSERTIONS
+
+check_two_file_sent
+
+SLEEP_INTERVAL_IN_SECONDS=10
+
+#set batch service send to false in order to not send the placeholder files
+export ACQ_BATCH_TRX_SENDER_ADE_ENABLED=false
+for (( i=0 ; i <= TIMEOUT_IN_MINUTES * 60 / SLEEP_INTERVAL_IN_SECONDS; i++))
+do
+    echo "Waiting $SLEEP_INTERVAL_IN_SECONDS seconds..."
+    sleep $SLEEP_INTERVAL_IN_SECONDS
+
+    # run batch service with dummy file
+    cp cstar-cli/generated/*.csv ./workdir/input/
+    run_batch_service
+
+    # check if file sent in the previous run has been received inside the report
+    get_file_sent_occurrence_in_report
+
+    # if report does contain the file sent the exit loop
+    if [ "$FILES_SENT_OCCURRENCES_IN_REPORT" -gt 0 ]
+    then
+        echo "Files found in report: [SUCCESS]"
+        break
+    fi
+
+done
+
+rm -rf cstar-cli
+rm -rf workdir
+
+exit 0

--- a/acceptance_tests/file_report/file_report_more_sender_codes.bash
+++ b/acceptance_tests/file_report/file_report_more_sender_codes.bash
@@ -82,7 +82,7 @@ run_batch_service
 run_batch_service
 
 #### ASSERTIONS
-check_two_file_sent
+check_two_files_sent
 
 SLEEP_INTERVAL_IN_SECONDS=10
 

--- a/acceptance_tests/file_report/file_report_more_sender_codes.bash
+++ b/acceptance_tests/file_report/file_report_more_sender_codes.bash
@@ -17,14 +17,16 @@ ENV=$1
 # timeout default 5minutes
 TIMEOUT_IN_MINUTES="${2:-5}"
 
+# Set sender codes
 SENDER_CODE1="${3-12345}"
 SENDER_CODE2="${4-54321}"
 
-sh ../common/setup.sh
 
 N_AGGREGATES=8
 
 REPORT_DIR=workdir/reports
+
+sh ../common/setup.sh
 
 echo "Make sure to have $SENDER_CODE1 and $SENDER_CODE2 associated with your API key"
 echo "Make sure to have empty cstar-cli/generated folder"
@@ -49,7 +51,7 @@ get_file_sent_occurrence_in_report() {
     FILES_SENT_OCCURRENCES_IN_REPORT=$(grep -c "$OUTPUT_FILENAME" < "$REPORT_DIR"/"$FILE_REPORT_NAME")
 }
 check_two_files_sent() {
-  # check if file has been uploaded
+  # check if the files has been uploaded
   N_UPLOADS=$(grep -c "uploaded with success (status was: 201)" < workdir/logs/application.log)
   if [ "$N_UPLOADS" -ne 2 ]
   then
@@ -68,21 +70,26 @@ generate_input_file
 source ../common/setenv_"$ENV".sh
 source setenv.sh
 
+# Disable batch scheduling for processing both files independently
 export ACQ_BATCH_SCHEDULED=false
+
+# Explicitly set the report directory
 export ACQ_BATCH_FILE_REPORT_PATH="$REPORT_DIR"
 
+# Batch service run for both files
 echo "Executing batch service..."
-### batch service run
 run_batch_service
 run_batch_service
-#### ASSERTIONS
 
+#### ASSERTIONS
 check_two_file_sent
 
 SLEEP_INTERVAL_IN_SECONDS=10
 
-#set batch service send to false in order to not send the placeholder files
+# Set batch service send to false in order to not send the placeholder files
 export ACQ_BATCH_TRX_SENDER_ADE_ENABLED=false
+
+# Wait for the report to be returned containing the two files
 for (( i=0 ; i <= TIMEOUT_IN_MINUTES * 60 / SLEEP_INTERVAL_IN_SECONDS; i++))
 do
     echo "Waiting $SLEEP_INTERVAL_IN_SECONDS seconds..."
@@ -95,7 +102,7 @@ do
     # check if file sent in the previous run has been received inside the report
     get_file_sent_occurrence_in_report
 
-    # if report does contain the file sent the exit loop
+    # if report does contain the files sent the exit loop
     if [ "$FILES_SENT_OCCURRENCES_IN_REPORT" -gt 0 ]
     then
         echo "Files found in report: [SUCCESS]"

--- a/acceptance_tests/file_report/file_report_more_sender_codes.bash
+++ b/acceptance_tests/file_report/file_report_more_sender_codes.bash
@@ -103,7 +103,7 @@ do
     get_file_sent_occurrence_in_report
 
     # if report does contain the files sent the exit loop
-    if [ "$FILES_SENT_OCCURRENCES_IN_REPORT" -gt 0 ]
+    if [ "$FILES_SENT_OCCURRENCES_IN_REPORT" -eq 2 ]
     then
         echo "Files found in report: [SUCCESS]"
         break


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add an acceptance test for file report feature.

#### List of Changes
- add acceptance test
<!--- Describe your changes in detail -->

#### Motivation and Context
With this change we can test the behavior of the batch service in case of files sent with multiple sender code, expecting a single report containing both of them.
The prerequisite is that the used API key must be associated with both sender codes in sender auth.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [x] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Chore change (non-breaking change which doesn't provide a direct value to users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
