### PR TITLE
fix: [RTD-1215] fix rows order in file report

### DIFF
--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/TransactionFilterStep.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/step/TransactionFilterStep.java
@@ -430,7 +430,6 @@ public class TransactionFilterStep {
             .reader(fileReportReader(restClient))
             .writer(fileReportWriter())
             .faultTolerant()
-            .taskExecutor(batchConfig.readerTaskExecutor())
             .build();
     }
 

--- a/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/TransactionFilterBatchFileReportTest.java
+++ b/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/TransactionFilterBatchFileReportTest.java
@@ -301,13 +301,15 @@ public class TransactionFilterBatchFileReportTest {
 
         List<String> fileReportContent = Files.readAllLines(fileReportSaved.stream().findAny()
             .orElse(new File("")).toPath());
-        assertThat(fileReportContent).isNotNull().contains("name;status;size;transmissionDate",
-            "file1;RECEIVED;200;" + currentDate);
+        assertThat(fileReportContent).isNotNull().containsExactly("name;status;size;transmissionDate",
+            "file1;RECEIVED;200;" + currentDate,
+            "file2;RECEIVED;300;" + currentDate.minusDays(4),
+            "file3;RECEIVED;400;" + currentDate.minusDays(10));
     }
 
     @SneakyThrows
     @Test
-    public void givenAReportWhenLaunchItThenSaveTheReportOnFile() {
+    public void givenAReportWhenLaunchFileReportStepThenSaveTheReportOnFile() {
         LocalDateTime currentDate = LocalDateTime.now();
         BDDMockito.doReturn(getStubFileReport(currentDate)).when(fileReportRestClient).getFileReport();
 
@@ -322,13 +324,15 @@ public class TransactionFilterBatchFileReportTest {
         List<String> fileReportContent = Files.readAllLines(fileReportSaved.stream().findAny()
             .orElse(new File("")).toPath());
 
-        assertThat(fileReportContent).isNotNull().contains("name;status;size;transmissionDate",
-            "file1;RECEIVED;200;" + currentDate);
+        assertThat(fileReportContent).isNotNull().containsExactly("name;status;size;transmissionDate",
+            "file1;RECEIVED;200;" + currentDate,
+            "file2;RECEIVED;300;" + currentDate.minusDays(4),
+            "file3;RECEIVED;400;" + currentDate.minusDays(10));
     }
 
     @SneakyThrows
     @Test
-    public void givenEmptyReportWhenLaunchItThenSaveTheReportWithHeaderOnly() {
+    public void givenEmptyReportWhenLaunchFileReportStepThenSaveTheReportWithHeaderOnly() {
         BDDMockito.doReturn(getStubEmptyReport()).when(fileReportRestClient).getFileReport();
 
         jobLauncherTestUtils.launchStep("file-report-recovery-step",
@@ -347,7 +351,7 @@ public class TransactionFilterBatchFileReportTest {
 
     @SneakyThrows
     @Test
-    public void givenMalformedReportWhenLaunchItThenSaveTheReportWithHeaderOnly() {
+    public void givenMalformedReportWhenLaunchFileReportStepThenSaveTheReportWithHeaderOnly() {
         // returns report with null field list
         BDDMockito.doReturn(new FileReport()).when(fileReportRestClient).getFileReport();
 
@@ -372,12 +376,30 @@ public class TransactionFilterBatchFileReportTest {
 
     private FileReport getStubFileReport(LocalDateTime dateTime) {
         FileReport fileReport = new FileReport();
+        List<FileMetadata> files = new ArrayList<>();
+
         FileMetadata fileMetadata = new FileMetadata();
         fileMetadata.setName("file1");
         fileMetadata.setSize(200L);
         fileMetadata.setTransmissionDate(dateTime);
         fileMetadata.setStatus("RECEIVED");
-        fileReport.setFilesRecentlyUploaded(Collections.singleton(fileMetadata));
+        files.add(fileMetadata);
+
+        fileMetadata = new FileMetadata();
+        fileMetadata.setName("file2");
+        fileMetadata.setSize(300L);
+        fileMetadata.setTransmissionDate(dateTime.minusDays(4));
+        fileMetadata.setStatus("RECEIVED");
+        files.add(fileMetadata);
+
+        fileMetadata = new FileMetadata();
+        fileMetadata.setName("file3");
+        fileMetadata.setSize(400L);
+        fileMetadata.setTransmissionDate(dateTime.minusDays(10));
+        fileMetadata.setStatus("RECEIVED");
+        files.add(fileMetadata);
+
+        fileReport.setFilesRecentlyUploaded(files);
 
         return fileReport;
     }

--- a/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/TransactionFilterBatchTest.java
+++ b/api/batch/src/test/java/it/gov/pagopa/rtd/transaction_filter/batch/TransactionFilterBatchTest.java
@@ -410,7 +410,7 @@ public class TransactionFilterBatchTest {
         fileMetadata.setSize(200L);
         fileMetadata.setTransmissionDate(dateTime);
         fileMetadata.setStatus("RECEIVED");
-        fileReport.setFilesRecentlyUploaded(Collections.singleton(fileMetadata));
+        fileReport.setFilesRecentlyUploaded(Collections.singletonList(fileMetadata));
 
         return fileReport;
     }

--- a/integration/rest/src/main/java/it/gov/pagopa/rtd/transaction_filter/connector/model/FileReport.java
+++ b/integration/rest/src/main/java/it/gov/pagopa/rtd/transaction_filter/connector/model/FileReport.java
@@ -1,10 +1,10 @@
 package it.gov.pagopa.rtd.transaction_filter.connector.model;
 
-import java.util.Collection;
+import java.util.List;
 import lombok.Data;
 
 @Data
 public class FileReport {
 
-  Collection<FileMetadata> filesRecentlyUploaded;
+  List<FileMetadata> filesRecentlyUploaded;
 }

--- a/integration/rest/src/test/java/it/gov/pagopa/rtd/transaction_filter/connector/FileReportRestClientTest.java
+++ b/integration/rest/src/test/java/it/gov/pagopa/rtd/transaction_filter/connector/FileReportRestClientTest.java
@@ -158,7 +158,7 @@ public class FileReportRestClientTest {
     FileMetadata file = new FileMetadata();
     // missing mandatory fields like filename
     file.setSize(200L);
-    fileReport.setFilesRecentlyUploaded(Collections.singleton(file));
+    fileReport.setFilesRecentlyUploaded(Collections.singletonList(file));
     return fileReport;
   }
 


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to maintain the row sorting of the file report between the JSON and the file saved. 

#### List of Changes

<!--- Describe your changes in detail -->
- Remove the task executor of the item writer step
- Refactor from Collection to List datatype to maintain the row sorting

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The batch service must save the file report on file with the same file sorting received in the JSON.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore change (non-breaking change which doesn't provide a direct value to users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
