### PR TITLE
feat: [RTD-1134] handle put error status 409

### DIFF
--- a/integration/rest/src/main/java/it/gov/pagopa/rtd/transaction_filter/connector/HpanRestClientImpl.java
+++ b/integration/rest/src/main/java/it/gov/pagopa/rtd/transaction_filter/connector/HpanRestClientImpl.java
@@ -283,11 +283,11 @@ class HpanRestClientImpl implements HpanRestClient {
     httpput.setEntity(entity);
     final HttpResponse response = httpclient.execute(httpput);
     if (response.getStatusLine().getStatusCode() != HttpStatus.SC_CREATED) {
-      throw new IOException("Upload failed for file " + fileToUpload.getName() + " (status was: "
-          + response.getStatusLine().getStatusCode() + ")");
+      handleErrorStatus(response.getStatusLine().getStatusCode(), fileToUpload.getName());
+    } else {
+      log.info("File {} uploaded with success (status was: {})", fileToUpload.getName(),
+          response.getStatusLine().getStatusCode());
     }
-    log.info("File " + fileToUpload.getName() + " uploaded with success (status was: "
-        + response.getStatusLine().getStatusCode() + ")");
     return null;
   }
 
@@ -297,6 +297,16 @@ class HpanRestClientImpl implements HpanRestClient {
     } else {
       throw new IllegalArgumentException(
           "One or more proxy parameters are null! Please set a value");
+    }
+  }
+
+  private void handleErrorStatus(int statusCode, String filename) throws IOException {
+    if (statusCode == HttpStatus.SC_CONFLICT) {
+      log.error("Upload failed for file {} (status was {}: File with same name has already been uploaded)",
+          filename, HttpStatus.SC_CONFLICT);
+    } else {
+      throw new IOException("Upload failed for file " + filename + " (status was: "
+          + statusCode + ")");
     }
   }
 


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to handle the response error code 409 on the upload api. 
The batch service won't retry the upload, won't move the file `into` pending folder but only log an error.

#### List of Changes

<!--- Describe your changes in detail -->
- changes on error code conditional flow
- updated unit test

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The error code 409 means a file with the same name has already been uploaded and the PUT api will keep failing. Besides, when an upload fails the file is moved to the `pending` folder, this must not happen in case of 409.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Chore change (non-breaking change which doesn't provide a direct value to users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
