### PR TITLE
fix: [RTD-1655] reduce log severity on ack confirm failure

### DIFF
--- a/api/batch/pom.xml
+++ b/api/batch/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>rtd-ms-transaction-filter-api</artifactId>
         <groupId>it.gov.pagopa.rtd.ms.transaction_filter.api</groupId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <artifactId>rtd-ms-transaction-filter-api-batch</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
 
     <dependencies>
         <dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <artifactId>rtd-ms-transaction-filter</artifactId>
         <groupId>it.gov.pagopa.rtd.ms</groupId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <groupId>it.gov.pagopa.rtd.ms.transaction_filter.api</groupId>
     <artifactId>rtd-ms-transaction-filter-api</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
 
     <packaging>pom</packaging>
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <artifactId>rtd-ms-transaction-filter</artifactId>
         <groupId>it.gov.pagopa.rtd.ms</groupId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <groupId>it.gov.pagopa.rtd.ms.transaction_filter</groupId>
     <artifactId>transaction-filter-app</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
 
     <dependencies>
         <dependency>

--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -116,7 +116,7 @@ batchConfiguration:
 rest-client:
   user-agent:
     prefix: BatchService
-    version: 2.0.2
+    version: 2.0.3
   hpan:
     serviceCode: hpan-service
     base-url: ${HPAN_SERVICE_URL:https://bpd-dev.azure-api.net:${HPAN_SERVICE_PORT:443}}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <artifactId>rtd-ms-transaction-filter</artifactId>
         <groupId>it.gov.pagopa.rtd.ms</groupId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
      </parent>
 
     <groupId>it.gov.pagopa.rtd.ms.transaction_filter</groupId>
     <artifactId>rtd-ms-transaction-filter-core</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
 
     <dependencies>
         <dependency>

--- a/integration/jpa/pom.xml
+++ b/integration/jpa/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <artifactId>rtd-ms-transaction-filter-integration</artifactId>
         <groupId>it.gov.pagopa.rtd.ms.transaction_filter</groupId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <groupId>it.gov.pagopa.rtd.ms.transaction_filter.integration</groupId>
     <artifactId>rtd-ms-transaction-filter-integration-jpa</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
 
     <dependencies>
         <dependency>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <artifactId>rtd-ms-transaction-filter</artifactId>
         <groupId>it.gov.pagopa.rtd.ms</groupId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <groupId>it.gov.pagopa.rtd.ms.transaction_filter</groupId>
     <artifactId>rtd-ms-transaction-filter-integration</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
 
     <packaging>pom</packaging>
 

--- a/integration/rest/pom.xml
+++ b/integration/rest/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>it.gov.pagopa.rtd.ms.transaction_filter</groupId>
         <artifactId>rtd-ms-transaction-filter-integration</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <groupId>it.gov.pagopa.rtd.ms.transaction_filter.integration</groupId>
     <artifactId>rtd-ms-transaction-filter-integration-rest</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
 
     <dependencies>
         <dependency>

--- a/integration/rest/src/main/java/it/gov/pagopa/rtd/transaction_filter/connector/SenderAdeAckRestClientImpl.java
+++ b/integration/rest/src/main/java/it/gov/pagopa/rtd/transaction_filter/connector/SenderAdeAckRestClientImpl.java
@@ -108,7 +108,7 @@ public class SenderAdeAckRestClientImpl implements SenderAdeAckRestClient {
       ResponseEntity<Void> responseEntity = hpanRestConnector.putAckReceived(apiKey, fileName, "");
       resourceValidator.validateStatus(responseEntity.getStatusCode());
     } catch (FeignException | ResponseStatusException ex) {
-      log.error("Cannot confirm {} file download! It will be downloaded on the next run.", fileName);
+      log.warn("Cannot confirm {} file download! It will be downloaded on the next run.", fileName);
       return false;
     }
     return true;

--- a/integration/rest/src/test/java/it/gov/pagopa/rtd/transaction_filter/logger/MaskingPatternLayoutTest.java
+++ b/integration/rest/src/test/java/it/gov/pagopa/rtd/transaction_filter/logger/MaskingPatternLayoutTest.java
@@ -38,7 +38,7 @@ class MaskingPatternLayoutTest {
     String stringWithSalt =
         "[HpanRestConnector#getSalt] ---> GET https://api.dev.cstar.pagopa.it/rtd/payment-instrument-manager/v2/salt HTTP/1.1\n"
             + "[HpanRestConnector#getSalt] Ocp-Apim-Subscription-Key: ciao\n"
-            + "[HpanRestConnector#getSalt] User-Agent: BatchService/2.0.2\n"
+            + "[HpanRestConnector#getSalt] User-Agent: BatchService/2.0.3\n"
             + "[HpanRestConnector#getSalt] ---> END HTTP (0-byte body)\n"
             + "[HpanRestConnector#getSalt] <--- HTTP/1.1 200 OK (57ms)\n"
             + "[HpanRestConnector#getSalt] connection: keep-alive\n"

--- a/ops_resources/example_config/application.yml
+++ b/ops_resources/example_config/application.yml
@@ -115,7 +115,7 @@ batchConfiguration:
 rest-client:
   user-agent:
     prefix: BatchService
-    version: 2.0.2
+    version: 2.0.3
   hpan:
     serviceCode: hpan-service
     base-url: ${HPAN_SERVICE_URL:https://bpd-dev.azure-api.net:${HPAN_SERVICE_PORT:443}}

--- a/ops_resources/example_config/application_hbsql.yml
+++ b/ops_resources/example_config/application_hbsql.yml
@@ -93,7 +93,7 @@ batchConfiguration:
 rest-client:
   user-agent:
     prefix: BatchService
-    version: 2.0.2
+    version: 2.0.3
   hpan:
     serviceCode: hpan-service
     base-url: ${HPAN_SERVICE_URL:https://bpd-dev.azure-api.net:${HPAN_SERVICE_PORT:443}}

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>it.gov.pagopa.rtd.ms</groupId>
     <artifactId>rtd-ms-transaction-filter</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
 
     <packaging>pom</packaging>
 
@@ -33,7 +33,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.exclusions>**/enums/**,**/model/**,**/Constants*.java,**/*Config.java,**/*Application.java
         </sonar.exclusions>
-        <transaction-filter.version>2.0.2</transaction-filter.version>
+        <transaction-filter.version>2.0.3</transaction-filter.version>
     </properties>
 
     <dependencyManagement>
@@ -54,11 +54,6 @@
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-openfeign</artifactId>
                 <version>${springframework-cloud.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>${snakeyaml.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to reduce the log severity from `error` to `warn` in case of failure of ack confirm api.
Bump pom version to 2.0.3 for next release

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore change (non-breaking change which doesn't provide a direct value to users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
