### PR TITLE
fix: [RTD-1669] fix conditional flow after ack fails

### DIFF
--- a/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/TransactionFilterBatch.java
+++ b/api/batch/src/main/java/it/gov/pagopa/rtd/transaction_filter/batch/TransactionFilterBatch.java
@@ -333,7 +333,7 @@ public class TransactionFilterBatch {
                 .on(FAILED).to(fileManagementTask())
                 .from(transactionFilterStep.transactionSenderRtdMasterStep(this.hpanConnectorService, this.storeService))
                 .on("*").to(senderAdeAckFilesRecoveryTask())
-                .next(pendingStepDecider(sendPendingFilesStepEnabled))
+                .on("*").to(pendingStepDecider(sendPendingFilesStepEnabled))
                 .on(TRUE).to(transactionFilterStep.transactionSenderPendingMasterStep(this.hpanConnectorService))
                 .from(pendingStepDecider(sendPendingFilesStepEnabled))
                 .on(FALSE).to(fileManagementTask())

--- a/integration/rest/src/main/java/it/gov/pagopa/rtd/transaction_filter/connector/SenderAdeAckRestClientImpl.java
+++ b/integration/rest/src/main/java/it/gov/pagopa/rtd/transaction_filter/connector/SenderAdeAckRestClientImpl.java
@@ -12,6 +12,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,13 +40,24 @@ public class SenderAdeAckRestClientImpl implements SenderAdeAckRestClient {
 
   @Override
   public List<File> getSenderAdeAckFiles() throws IOException {
-    ResponseEntity<SenderAdeAckList> senderAdeAckResponse = hpanRestConnector.getSenderAdeAckList(
-        apiKey);
+    SenderAdeAckList adeAckList = retrieveAdeAckList();
 
-    senderAdeAckValidator.validate(senderAdeAckResponse);
+    return downloadFiles(adeAckList.getFileNameList());
+  }
 
-    SenderAdeAckList senderAdeAckDto = Objects.requireNonNull(senderAdeAckResponse.getBody());
-    return downloadFiles(senderAdeAckDto.getFileNameList());
+  private SenderAdeAckList retrieveAdeAckList() {
+    SenderAdeAckList senderAdeAckList = null;
+    try {
+      ResponseEntity<SenderAdeAckList> adeAckResponse = hpanRestConnector.getSenderAdeAckList(
+          apiKey);
+      senderAdeAckValidator.validate(adeAckResponse);
+
+      senderAdeAckList = adeAckResponse.getBody();
+    } catch (FeignException | ResponseStatusException ex) {
+      log.warn("Failed to download ade ack list! It will be downloaded on the next run.");
+    }
+
+    return Objects.requireNonNull(senderAdeAckList);
   }
 
   private List<File> downloadFiles(List<String> fileNameList) throws IOException {
@@ -55,20 +67,14 @@ public class SenderAdeAckRestClientImpl implements SenderAdeAckRestClient {
     Path temporaryDirectory = Files.createTempDirectory(tempDir.toPath(), "senderAdeAck");
 
     for (String fileName : fileNameList) {
-      ResponseEntity<Resource> resourceResponseEntity = hpanRestConnector.getSenderAdeAckFile(
-          apiKey, fileName);
-
-      resourceValidator.validateStatus(resourceResponseEntity.getStatusCode());
-
-      Resource resource = resourceResponseEntity.getBody();
-      if (resource == null) {
-        log.warn("received empty file");
+      Optional<Resource> resource = downloadAdeAck(fileName);
+      if (!resource.isPresent()) {
         // skip to next file
         continue;
       }
 
       File tempFile = createTempFile(fileName, temporaryDirectory);
-      copyFromResourceToFile(resource, tempFile);
+      copyFromResourceToFile(resource.get(), tempFile);
 
       boolean isDownloadConfirmed = sendAckReceivedConfirmation(fileName);
       if (isDownloadConfirmed) {
@@ -87,6 +93,21 @@ public class SenderAdeAckRestClientImpl implements SenderAdeAckRestClient {
     return filesDownloaded;
   }
 
+  private Optional<Resource> downloadAdeAck(String fileName) {
+    Resource adeAckResource = null;
+    try {
+      ResponseEntity<Resource> resourceResponseEntity = hpanRestConnector.getSenderAdeAckFile(
+          apiKey, fileName);
+      resourceValidator.validateStatus(resourceResponseEntity.getStatusCode());
+
+      adeAckResource = resourceResponseEntity.getBody();
+    } catch (FeignException | ResponseStatusException ex) {
+      log.warn("Failed to download the ack: {}! It will be downloaded on the next run.", fileName);
+    }
+
+    return Optional.ofNullable(adeAckResource);
+  }
+
   private File createTempFile(@NotNull String filename, @NotNull Path directory)
       throws IOException {
     return Files.createFile(Paths.get(directory.toString()
@@ -96,8 +117,7 @@ public class SenderAdeAckRestClientImpl implements SenderAdeAckRestClient {
 
   private void copyFromResourceToFile(@NotNull Resource resource, @NotNull File file)
       throws IOException {
-    try (
-        FileOutputStream tempFileFOS = new FileOutputStream(file);
+    try (FileOutputStream tempFileFOS = new FileOutputStream(file);
         InputStream inputStream = resource.getInputStream()) {
       StreamUtils.copy(inputStream, tempFileFOS);
     }

--- a/integration/rest/src/main/java/it/gov/pagopa/rtd/transaction_filter/connector/SenderAdeAckRestClientImpl.java
+++ b/integration/rest/src/main/java/it/gov/pagopa/rtd/transaction_filter/connector/SenderAdeAckRestClientImpl.java
@@ -46,7 +46,7 @@ public class SenderAdeAckRestClientImpl implements SenderAdeAckRestClient {
   }
 
   private SenderAdeAckList retrieveAdeAckList() {
-    SenderAdeAckList senderAdeAckList = null;
+    SenderAdeAckList senderAdeAckList;
     try {
       ResponseEntity<SenderAdeAckList> adeAckResponse = hpanRestConnector.getSenderAdeAckList(
           apiKey);
@@ -55,6 +55,8 @@ public class SenderAdeAckRestClientImpl implements SenderAdeAckRestClient {
       senderAdeAckList = adeAckResponse.getBody();
     } catch (FeignException | ResponseStatusException ex) {
       log.warn("Failed to download ade ack list! It will be downloaded on the next run.");
+      // returns an empty list
+      return new SenderAdeAckList();
     }
 
     return Objects.requireNonNull(senderAdeAckList);

--- a/integration/rest/src/main/java/it/gov/pagopa/rtd/transaction_filter/connector/SenderAdeAckRestClientImpl.java
+++ b/integration/rest/src/main/java/it/gov/pagopa/rtd/transaction_filter/connector/SenderAdeAckRestClientImpl.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import javax.validation.ValidationException;
 import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,7 +54,7 @@ public class SenderAdeAckRestClientImpl implements SenderAdeAckRestClient {
       senderAdeAckValidator.validate(adeAckResponse);
 
       senderAdeAckList = adeAckResponse.getBody();
-    } catch (FeignException | ResponseStatusException ex) {
+    } catch (FeignException | ResponseStatusException | ValidationException ex) {
       log.warn("Failed to download ade ack list! It will be downloaded on the next run.");
       // returns an empty list
       return new SenderAdeAckList();

--- a/integration/rest/src/test/java/it/gov/pagopa/rtd/transaction_filter/connector/SenderAdeAckRestClientTest.java
+++ b/integration/rest/src/test/java/it/gov/pagopa/rtd/transaction_filter/connector/SenderAdeAckRestClientTest.java
@@ -144,6 +144,17 @@ public class SenderAdeAckRestClientTest {
 
   @SneakyThrows
   @Test
+  public void whenDownloadFileReturns404ThenDoNotSaveTheFile() {
+    wireMockRule.stubFor(get(urlPathMatching("/ade/.*"))
+        .willReturn(aResponse().withStatus(404)));
+
+    List<File> files = restClient.getSenderAdeAckFiles();
+
+    assertThat(files).isNotNull().isEmpty();
+  }
+
+  @SneakyThrows
+  @Test
   public void whenAdeAckListApiReturnsEmptyBodyThenRaisesException() {
     wireMockRule.stubFor(get("/rtd/file-register/sender-ade-ack")
         .willReturn(aResponse()));

--- a/integration/rest/src/test/java/it/gov/pagopa/rtd/transaction_filter/connector/SenderAdeAckRestClientTest.java
+++ b/integration/rest/src/test/java/it/gov/pagopa/rtd/transaction_filter/connector/SenderAdeAckRestClientTest.java
@@ -154,6 +154,17 @@ public class SenderAdeAckRestClientTest {
 
   @SneakyThrows
   @Test
+  public void whenAdeAckListReturns404ThenReturnsEmptyList() {
+    wireMockRule.stubFor(get("/rtd/file-register/sender-ade-ack")
+        .willReturn(aResponse().withStatus(404)));
+
+    List<File> files = restClient.getSenderAdeAckFiles();
+
+    assertThat(files).isEmpty();
+  }
+
+  @SneakyThrows
+  @Test
   public void whenPutAckReceivedReturns404ThenReturnsNoFilesAndDeleteTempOnes() {
     wireMockRule.stubFor(put(urlPathMatching("/rtd/file-register/ack-received/.*"))
         .willReturn(aResponse().withStatus(404)));


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to fix a bug in the conditional flow after the ade-ack download step. Atm when the ade-ack-list step fails the filemanagement step is skipped and the job ends. Desiderata is: when ade-ack-list step fails then the filemanagement step is executed.

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore change (non-breaking change which doesn't provide a direct value to users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
